### PR TITLE
Refactor jail utilities

### DIFF
--- a/backend/routes/report.js
+++ b/backend/routes/report.js
@@ -2,7 +2,8 @@ const express = require("express");
 const router = express.Router();
 const mongoose = require("mongoose");
 const Civilian = mongoose.models.Civilian || require("../models/Civilian");
-const { jailUser, trackFine } = require("../bot");
+const { jailUser } = require("../utilities");
+const { trackFine, client } = require("../bot");
 const { Types } = require("mongoose");
 
 router.post("/create", async (req, res) => {
@@ -46,8 +47,8 @@ router.post("/create", async (req, res) => {
     await civilian.save();
 
     if (jailTime && jailTime > 0) {
-      jailUser(civilian.discordId, jailTime, platform.toLowerCase());
-    }   
+      jailUser(client, civilian.discordId, jailTime, platform.toLowerCase());
+    }
 
     return res.json({ recordId: reportId });
   } catch (err) {

--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const mongoose = require("mongoose");
 const Civilian = mongoose.models.Civilian || require("../models/Civilian");
 const { Types } = require("mongoose");
-const { jailUser, trackFine } = require("../bot");
+const { jailUser } = require("../utilities");
+const { trackFine, client } = require("../bot");
 
 // POST /api/reports/create
 router.post("/create", async (req, res) => {
@@ -48,7 +49,7 @@ router.post("/create", async (req, res) => {
     await civilian.save();
 
     if (jailTime && jailTime > 0) {
-      jailUser(civilian.discordId, jailTime, platform.toLowerCase());
+      jailUser(client, civilian.discordId, jailTime, platform.toLowerCase());
     }
 
     return res.json({ recordId: reportId });

--- a/backend/utilities.js
+++ b/backend/utilities.js
@@ -1,0 +1,67 @@
+const { EmbedBuilder } = require('discord.js');
+
+function sendDM(member, embed) {
+  return member.send({ embeds: [embed] }).catch(err => console.warn("Failed to DM member:", err));
+}
+
+function scheduleFineCheck(client, warrantChannels, civilian, report, message, platform) {
+  setTimeout(async () => {
+    if (report.paid) return;
+
+    const updatedEmbed = EmbedBuilder.from(message.embeds[0])
+      .setFooter({ text: `Status: UNPAID` })
+      .setColor('Red');
+
+    await message.edit({ embeds: [updatedEmbed], components: [] });
+
+    const warrantEmbed = new EmbedBuilder()
+      .setTitle('🚨 Warrant Issued')
+      .setDescription(`**${civilian.firstName} ${civilian.lastName}** failed to pay a fine of **$${report.fine}**.`)
+      .setColor('Red')
+      .setTimestamp();
+
+    const channelId = warrantChannels[platform];
+    const channel = await client.channels.fetch(channelId);
+    await channel.send({ embeds: [warrantEmbed] });
+  }, 1000 * 60 * 60 * 24); // 24 hours
+}
+
+const jailRoles = {
+  xbox: '1376268599924232202',
+  playstation: '1376268687656353914'
+};
+
+function jailUser(client, discordId, jailTime, platform) {
+  client.guilds.fetch(process.env[platform.toUpperCase() + '_GUILD_ID']).then(async guild => {
+    const member = await guild.members.fetch(discordId);
+    const jailRoleId = jailRoles[platform];
+    await member.roles.add(jailRoleId);
+
+    const releaseTime = Date.now() + jailTime * 60000;
+    const interval = setInterval(async () => {
+      if (Date.now() >= releaseTime) {
+        clearInterval(interval);
+        await member.roles.remove(jailRoleId);
+        const releaseEmbed = new EmbedBuilder()
+          .setTitle('🔓 Released from Jail')
+          .setDescription(`You have completed your **${jailTime} minute** sentence.`)
+          .setColor('Green');
+        await sendDM(member, releaseEmbed);
+      }
+    }, 10000);
+
+    const jailEmbed = new EmbedBuilder()
+      .setTitle('⛓️ You Have Been Jailed')
+      .setDescription(`You were jailed for **${jailTime} minutes**.`)
+      .setFooter({ text: 'You will be released automatically.' })
+      .setColor('Orange');
+
+    await sendDM(member, jailEmbed);
+  });
+}
+
+module.exports = {
+  sendDM,
+  scheduleFineCheck,
+  jailUser
+};


### PR DESCRIPTION
## Summary
- consolidate helper utilities into a new `utilities.js`
- reuse utilities inside the bot and routes
- remove duplicated `scheduleFineCheck`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850a5b6950c833091eb98c337ea4e35