### PR TITLE
Add modular bot service layer

### DIFF
--- a/backend/bot/services/bankService.js
+++ b/backend/bot/services/bankService.js
@@ -1,0 +1,29 @@
+const BankAccount = require('../../models/BankAccount');
+const Civilian = require('../../models/Civilian');
+
+async function approveAccount(accountId) {
+  const account = await BankAccount.findById(accountId);
+  if (!account) throw new Error('Account not found');
+  account.needsApproval = false;
+  account.status = 'approved';
+  return account.save();
+}
+
+async function denyAccount(accountId) {
+  const account = await BankAccount.findById(accountId);
+  if (!account) throw new Error('Account not found');
+  await BankAccount.findByIdAndDelete(accountId);
+  return account;
+}
+
+async function createAccount({ civilianId, accountType, needsApproval = false, reason }) {
+  const accountNumber = Math.floor(100000000 + Math.random() * 900000000).toString();
+  const status = needsApproval ? 'pending' : 'approved';
+  return BankAccount.create({ civilianId, accountType, reason, accountNumber, status, needsApproval, balance: 0 });
+}
+
+module.exports = {
+  approveAccount,
+  denyAccount,
+  createAccount,
+};

--- a/backend/bot/services/clockService.js
+++ b/backend/bot/services/clockService.js
@@ -1,0 +1,32 @@
+const ClockSession = require('../../models/ClockSession');
+
+async function clockIn(discordId, officerInfo = {}) {
+  const existing = await ClockSession.findOne({ discordId, clockOutTime: null });
+  if (existing) {
+    throw new Error('Already clocked in');
+  }
+  return ClockSession.create({
+    discordId,
+    officerName: officerInfo.officerName || '',
+    callsign: officerInfo.callsign || '',
+    department: officerInfo.department || '',
+    clockInTime: new Date(),
+  });
+}
+
+async function clockOut(discordId) {
+  const session = await ClockSession.findOne({ discordId, clockOutTime: null });
+  if (!session) {
+    throw new Error('Not clocked in');
+  }
+  const now = new Date();
+  session.clockOutTime = now;
+  session.duration = Math.floor((now - session.clockInTime) / 1000);
+  await session.save();
+  return session;
+}
+
+module.exports = {
+  clockIn,
+  clockOut,
+};

--- a/backend/bot/services/storeService.js
+++ b/backend/bot/services/storeService.js
@@ -1,0 +1,41 @@
+const StoreItem = require('../../models/StoreItem');
+const Inventory = require('../../models/Inventory');
+const { deductFunds, getWallet } = require('./walletService');
+
+async function getItems() {
+  return StoreItem.find();
+}
+
+async function getItemByName(name) {
+  return StoreItem.findOne({ name: new RegExp(`^${name}$`, 'i') });
+}
+
+async function addItem(data) {
+  return StoreItem.create(data);
+}
+
+async function purchaseItem(discordId, item, member) {
+  if (typeof item === 'string') {
+    item = await getItemByName(item);
+  }
+  if (!item) {
+    throw new Error('Item not found');
+  }
+  if (item.roleRequirement && member && !member.roles.cache.has(item.roleRequirement)) {
+    throw new Error('Missing required role');
+  }
+  await deductFunds(discordId, item.price);
+  await Inventory.findOneAndUpdate(
+    { discordId },
+    { $push: { items: { name: item.name, price: item.price, purchasedAt: new Date() } } },
+    { upsert: true, new: true }
+  );
+  return item;
+}
+
+module.exports = {
+  getItems,
+  getItemByName,
+  addItem,
+  purchaseItem,
+};

--- a/backend/bot/services/walletService.js
+++ b/backend/bot/services/walletService.js
@@ -1,0 +1,40 @@
+const Wallet = require('../../models/Wallet');
+
+async function getWallet(discordId) {
+  let wallet = await Wallet.findOne({ discordId });
+  if (!wallet) {
+    wallet = await Wallet.create({ discordId });
+  }
+  return wallet;
+}
+
+async function addFunds(discordId, amount) {
+  const wallet = await getWallet(discordId);
+  wallet.balance += amount;
+  await wallet.save();
+  return wallet;
+}
+
+async function setBalance(discordId, amount) {
+  const wallet = await getWallet(discordId);
+  wallet.balance = amount;
+  await wallet.save();
+  return wallet;
+}
+
+async function deductFunds(discordId, amount) {
+  const wallet = await getWallet(discordId);
+  if (wallet.balance < amount) {
+    throw new Error('Insufficient funds');
+  }
+  wallet.balance -= amount;
+  await wallet.save();
+  return wallet;
+}
+
+module.exports = {
+  getWallet,
+  addFunds,
+  setBalance,
+  deductFunds,
+};


### PR DESCRIPTION
## Summary
- implement service helpers for bot commands
- add wallet, store, bank and clock services under `backend/bot/services`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850a5b8daa48330b72fd73c26a7f23c