### PR TITLE
Improve error handling for Discord utilities

### DIFF
--- a/backend/bot/utils/assignLicenseRole.js
+++ b/backend/bot/utils/assignLicenseRole.js
@@ -4,13 +4,20 @@ const ROLE_MAP = {
   "CDL Class A": process.env.ROLE_CDL_A,
   "CDL Class B": process.env.ROLE_CDL_B,
 };
+const logError = require('./logError');
 
 async function assignLicenseRole(client, discordId, licenseType) {
-  const guild = await client.guilds.fetch(process.env.DISCORD_GUILD_ID);
-  const member = await guild.members.fetch(discordId);
-  const roleId = ROLE_MAP[licenseType];
-  if (!roleId) throw new Error(`No role ID mapped for ${licenseType}`);
-  await member.roles.add(roleId);
+  try {
+    const guild = await client.guilds.fetch(process.env.DISCORD_GUILD_ID);
+    const member = await guild.members.fetch(discordId);
+    const roleId = ROLE_MAP[licenseType];
+    if (!roleId) throw new Error(`No role ID mapped for ${licenseType}`);
+    await member.roles.add(roleId);
+    return true;
+  } catch (err) {
+    logError('Assign license role', err);
+    return false;
+  }
 }
 
 module.exports = assignLicenseRole;

--- a/backend/bot/utils/logError.js
+++ b/backend/bot/utils/logError.js
@@ -1,0 +1,4 @@
+function logError(context, error) {
+  console.error(`\u274c ${context}:`, error);
+}
+module.exports = logError;

--- a/backend/bot/utils/scheduleFineCheck.js
+++ b/backend/bot/utils/scheduleFineCheck.js
@@ -1,4 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
+const logError = require('./logError');
 
 const warrantChannels = {
   xbox: '1376269149785034842',
@@ -7,23 +8,27 @@ const warrantChannels = {
 
 function scheduleFineCheck(client, civilian, report, message, platform) {
   setTimeout(async () => {
-    if (report.paid) return;
+    try {
+      if (report.paid) return;
 
-    const updatedEmbed = EmbedBuilder.from(message.embeds[0])
-      .setFooter({ text: 'Status: UNPAID' })
-      .setColor('Red');
+      const updatedEmbed = EmbedBuilder.from(message.embeds[0])
+        .setFooter({ text: 'Status: UNPAID' })
+        .setColor('Red');
 
-    await message.edit({ embeds: [updatedEmbed], components: [] });
+      await message.edit({ embeds: [updatedEmbed], components: [] });
 
-    const warrantEmbed = new EmbedBuilder()
-      .setTitle('🚨 Warrant Issued')
-      .setDescription(`**${civilian.firstName} ${civilian.lastName}** failed to pay a fine of **$${report.fine}**.`)
-      .setColor('Red')
-      .setTimestamp();
+      const warrantEmbed = new EmbedBuilder()
+        .setTitle('🚨 Warrant Issued')
+        .setDescription(`**${civilian.firstName} ${civilian.lastName}** failed to pay a fine of **$${report.fine}**.`)
+        .setColor('Red')
+        .setTimestamp();
 
-    const channelId = warrantChannels[platform];
-    const channel = await client.channels.fetch(channelId);
-    await channel.send({ embeds: [warrantEmbed] });
+      const channelId = warrantChannels[platform];
+      const channel = await client.channels.fetch(channelId);
+      await channel.send({ embeds: [warrantEmbed] });
+    } catch (err) {
+      logError('Schedule fine check', err);
+    }
   }, 1000 * 60 * 60 * 24);
 }
 

--- a/backend/bot/utils/sendBankApprovalEmbed.js
+++ b/backend/bot/utils/sendBankApprovalEmbed.js
@@ -1,8 +1,10 @@
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const logError = require('./logError');
 
 async function sendBankApprovalEmbed(client, civilianName, discordId, accountType, reason, accountId, accountNumber) {
-  const channel = await client.channels.fetch('1373043842340622436');
-  const embed = new EmbedBuilder()
+  try {
+    const channel = await client.channels.fetch('1373043842340622436');
+    const embed = new EmbedBuilder()
     .setTitle('📝 New Bank Account Request')
     .addFields(
       { name: 'Civilian Name', value: civilianName },
@@ -14,7 +16,7 @@ async function sendBankApprovalEmbed(client, civilianName, discordId, accountTyp
     .setColor('Orange')
     .setTimestamp();
 
-  const row = new ActionRowBuilder().addComponents(
+    const row = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(`approve_bank_${accountId}`)
       .setLabel('Approve')
@@ -25,7 +27,12 @@ async function sendBankApprovalEmbed(client, civilianName, discordId, accountTyp
       .setStyle(ButtonStyle.Danger)
   );
 
-  await channel.send({ embeds: [embed], components: [row] });
+    await channel.send({ embeds: [embed], components: [row] });
+    return true;
+  } catch (err) {
+    logError('Send bank approval embed', err);
+    return false;
+  }
 }
 
 module.exports = sendBankApprovalEmbed;

--- a/backend/bot/utils/sendClockEmbed.js
+++ b/backend/bot/utils/sendClockEmbed.js
@@ -1,23 +1,30 @@
 const { EmbedBuilder } = require('discord.js');
+const logError = require('./logError');
 
 async function sendClockEmbed(client, { officer, discordId, type, duration }) {
-  const user = await client.users.fetch(discordId);
-  const platform = officer.department.toLowerCase();
-  const logChannelId = platform === 'xbox' ? process.env.LOG_CHANNEL_XBOX : process.env.LOG_CHANNEL_PLAYSTATION;
-  const logChannel = await client.channels.fetch(logChannelId).catch(() => null);
+  try {
+    const user = await client.users.fetch(discordId);
+    const platform = officer.department.toLowerCase();
+    const logChannelId = platform === 'xbox' ? process.env.LOG_CHANNEL_XBOX : process.env.LOG_CHANNEL_PLAYSTATION;
+    const logChannel = await client.channels.fetch(logChannelId).catch(() => null);
 
-  const embed = new EmbedBuilder()
-    .setTitle(type === 'in' ? '🟢 Officer Clocked In' : '🔴 Officer Clocked Out')
-    .addFields(
-      { name: 'Officer', value: `${officer.callsign} (${officer.badgeNumber})`, inline: true },
-      { name: 'Status', value: type === 'in' ? 'Clocked In' : `Clocked Out (${duration})`, inline: true }
-    )
-    .setFooter({ text: type === 'in' ? 'Duty started.' : 'Duty ended.' })
-    .setColor(type === 'in' ? 0x00ff00 : 0xff0000)
-    .setTimestamp();
+    const embed = new EmbedBuilder()
+      .setTitle(type === 'in' ? '🟢 Officer Clocked In' : '🔴 Officer Clocked Out')
+      .addFields(
+        { name: 'Officer', value: `${officer.callsign} (${officer.badgeNumber})`, inline: true },
+        { name: 'Status', value: type === 'in' ? 'Clocked In' : `Clocked Out (${duration})`, inline: true }
+      )
+      .setFooter({ text: type === 'in' ? 'Duty started.' : 'Duty ended.' })
+      .setColor(type === 'in' ? 0x00ff00 : 0xff0000)
+      .setTimestamp();
 
-  if (user) await user.send({ embeds: [embed] }).catch(() => null);
-  if (logChannel) await logChannel.send({ embeds: [embed] });
+    if (user) await user.send({ embeds: [embed] }).catch(err => logError('Send clock embed DM', err));
+    if (logChannel) await logChannel.send({ embeds: [embed] });
+    return true;
+  } catch (err) {
+    logError('Send clock embed', err);
+    return false;
+  }
 }
 
 module.exports = sendClockEmbed;

--- a/backend/bot/utils/trackFine.js
+++ b/backend/bot/utils/trackFine.js
@@ -1,17 +1,25 @@
+const logError = require('./logError');
+
 async function trackFine(client, { civilianId, reportId, messageId, channelId, platform }) {
-  const Civilian = require('../../models/Civilian');
-  const civilian = await Civilian.findById(civilianId);
-  if (!civilian) return;
+  try {
+    const Civilian = require('../../models/Civilian');
+    const civilian = await Civilian.findById(civilianId);
+    if (!civilian) return false;
 
-  const report = civilian.reports.find(r => r.reportId?.toString() === reportId);
-  if (!report) return;
+    const report = civilian.reports.find(r => r.reportId?.toString() === reportId);
+    if (!report) return false;
 
-  const channel = await client.channels.fetch(channelId);
-  const message = await channel.messages.fetch(messageId).catch(() => null);
-  if (!message) return;
+    const channel = await client.channels.fetch(channelId);
+    const message = await channel.messages.fetch(messageId).catch(() => null);
+    if (!message) return false;
 
-  const scheduleFineCheck = require('./scheduleFineCheck');
-  scheduleFineCheck(client, civilian, report, message, platform);
+    const scheduleFineCheck = require('./scheduleFineCheck');
+    scheduleFineCheck(client, civilian, report, message, platform);
+    return true;
+  } catch (err) {
+    logError('Track fine', err);
+    return false;
+  }
 }
 
 module.exports = trackFine;


### PR DESCRIPTION
## Summary
- handle exceptions in Discord utility functions
- add consistent error logging utility

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850aaa17c908330af452c1417e6604d