### PR TITLE
Add user management and store admin commands

### DIFF
--- a/backend/bot/commands/buy.js
+++ b/backend/bot/commands/buy.js
@@ -9,7 +9,7 @@ module.exports = {
     .setName('buy')
     .setDescription('Purchase an item from the store')
     .addStringOption(opt =>
-      opt.setName('name').setDescription('Name of the item to purchase').setRequired(true)
+      opt.setName('name').setDescription('Name of the item to purchase').setRequired(true).setAutocomplete(true)
     ),
   async execute(interaction) {
     const name = interaction.options.getString('name');
@@ -57,5 +57,10 @@ module.exports = {
     if (item.image) embed.setImage(item.image);
 
     return interaction.reply({ embeds: [embed], ephemeral: true });
+  },
+  async autocomplete(interaction) {
+    const focused = interaction.options.getFocused();
+    const items = await StoreItem.find({ name: { $regex: focused, $options: 'i' } }).limit(25);
+    await interaction.respond(items.map(i => ({ name: i.name, value: i.name })));
   }
 };

--- a/backend/bot/commands/iteminfo.js
+++ b/backend/bot/commands/iteminfo.js
@@ -5,7 +5,7 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('iteminfo')
     .setDescription('Get detailed information about a store item')
-    .addStringOption(opt => opt.setName('name').setDescription('Name of the item').setRequired(true)),
+    .addStringOption(opt => opt.setName('name').setDescription('Name of the item').setRequired(true).setAutocomplete(true)),
   async execute(interaction) {
     const name = interaction.options.getString('name');
     const item = await StoreItem.findOne({ name: new RegExp(`^${name}$`, 'i') });
@@ -27,5 +27,10 @@ module.exports = {
     if (item.image) embed.setImage(item.image);
 
     return interaction.reply({ embeds: [embed], ephemeral: true });
+  },
+  async autocomplete(interaction) {
+    const focused = interaction.options.getFocused();
+    const items = await StoreItem.find({ name: { $regex: focused, $options: 'i' } }).limit(25);
+    await interaction.respond(items.map(i => ({ name: i.name, value: i.name })));
   }
 };

--- a/backend/bot/commands/store-manage.js
+++ b/backend/bot/commands/store-manage.js
@@ -1,0 +1,77 @@
+const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
+const StoreItem = require('../../models/StoreItem');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('store-manage')
+    .setDescription('Edit or delete store items')
+    .addSubcommand(sub =>
+      sub.setName('edit')
+        .setDescription('Edit a store item')
+        .addStringOption(opt => opt.setName('name').setDescription('Item name').setRequired(true).setAutocomplete(true))
+        .addNumberOption(opt => opt.setName('price').setDescription('New price').setRequired(false))
+        .addStringOption(opt => opt.setName('description').setDescription('New description').setRequired(false))
+        .addStringOption(opt => opt.setName('image').setDescription('Image URL').setRequired(false))
+        .addRoleOption(opt => opt.setName('role').setDescription('Role requirement').setRequired(false))
+    )
+    .addSubcommand(sub =>
+      sub.setName('delete')
+        .setDescription('Delete a store item')
+        .addStringOption(opt => opt.setName('name').setDescription('Item name').setRequired(true).setAutocomplete(true))
+    ),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.Administrator)) {
+      return interaction.reply({ content: '❌ Admins only.', ephemeral: true });
+    }
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'edit') {
+      const name = interaction.options.getString('name');
+      const item = await StoreItem.findOne({ name: new RegExp(`^${name}$`, 'i') });
+      if (!item) {
+        return interaction.reply({ content: `❌ No item named "${name}" found.`, ephemeral: true });
+      }
+      const price = interaction.options.getNumber('price');
+      const description = interaction.options.getString('description');
+      const image = interaction.options.getString('image');
+      const role = interaction.options.getRole('role');
+
+      if (price !== null && price !== undefined) item.price = price;
+      if (description) item.description = description;
+      if (image) item.image = image;
+      if (role) item.roleRequirement = role.id;
+      await item.save();
+
+      const embed = new EmbedBuilder()
+        .setColor('Blue')
+        .setTitle('✅ Item Updated')
+        .setDescription(`Updated **${item.name}**.`)
+        .addFields(
+          { name: 'Price', value: `$${item.price.toFixed(2)}`, inline: true },
+          { name: 'Role', value: item.roleRequirement ? `<@&${item.roleRequirement}>` : 'None', inline: true }
+        )
+        .setTimestamp();
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+
+    if (sub === 'delete') {
+      const name = interaction.options.getString('name');
+      const item = await StoreItem.findOneAndDelete({ name: new RegExp(`^${name}$`, 'i') });
+      if (!item) {
+        return interaction.reply({ content: `❌ No item named "${name}" found.`, ephemeral: true });
+      }
+      const embed = new EmbedBuilder()
+        .setColor('Red')
+        .setTitle('🗑️ Item Deleted')
+        .setDescription(`Deleted **${item.name}** from the store.`)
+        .setTimestamp();
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+  },
+  async autocomplete(interaction) {
+    const focused = interaction.options.getFocused();
+    const items = await StoreItem.find({ name: { $regex: focused, $options: 'i' } }).limit(25);
+    await interaction.respond(items.map(i => ({ name: i.name, value: i.name })));
+  }
+};

--- a/backend/bot/commands/useradd.js
+++ b/backend/bot/commands/useradd.js
@@ -1,0 +1,70 @@
+const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder, userMention } = require('discord.js');
+const Wallet = require('../../models/Wallet');
+const Inventory = require('../../models/Inventory');
+const StoreItem = require('../../models/StoreItem');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('useradd')
+    .setDescription('Add money or items to a user')
+    .addSubcommand(sub =>
+      sub.setName('money')
+        .setDescription('Add money to a user')
+        .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+        .addNumberOption(opt => opt.setName('amount').setDescription('Amount to add').setRequired(true))
+    )
+    .addSubcommand(sub =>
+      sub.setName('item')
+        .setDescription('Add an item to a user')
+        .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+        .addStringOption(opt => opt.setName('name').setDescription('Item name').setRequired(true).setAutocomplete(true))
+    ),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.Administrator)) {
+      return interaction.reply({ content: '❌ Admins only.', ephemeral: true });
+    }
+
+    const sub = interaction.options.getSubcommand();
+    const user = interaction.options.getUser('user');
+    const discordId = user.id;
+
+    if (sub === 'money') {
+      const amount = interaction.options.getNumber('amount');
+      const wallet = await Wallet.findOne({ discordId }) || await Wallet.create({ discordId });
+      wallet.balance += amount;
+      await wallet.save();
+      const embed = new EmbedBuilder()
+        .setColor('Green')
+        .setTitle('✅ Money Added')
+        .setDescription(`Added $${amount.toFixed(2)} to ${userMention(discordId)}'s wallet.`)
+        .addFields({ name: 'New Balance', value: `$${wallet.balance.toFixed(2)}` })
+        .setTimestamp();
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+
+    if (sub === 'item') {
+      const name = interaction.options.getString('name');
+      const item = await StoreItem.findOne({ name: new RegExp(`^${name}$`, 'i') });
+      if (!item) {
+        return interaction.reply({ content: `❌ No item named "${name}" found in the store.`, ephemeral: true });
+      }
+      await Inventory.findOneAndUpdate(
+        { discordId },
+        { $push: { items: { name: item.name, price: item.price, purchasedAt: new Date() } } },
+        { upsert: true, new: true }
+      );
+      const embed = new EmbedBuilder()
+        .setColor('Green')
+        .setTitle('📦 Item Added')
+        .setDescription(`Added **${item.name}** to ${userMention(discordId)}'s inventory.`)
+        .setTimestamp();
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+  },
+  async autocomplete(interaction) {
+    if (interaction.options.getSubcommand() !== 'item') return;
+    const focused = interaction.options.getFocused();
+    const items = await StoreItem.find({ name: { $regex: focused, $options: 'i' } }).limit(25);
+    await interaction.respond(items.map(i => ({ name: i.name, value: i.name })));
+  }
+};

--- a/backend/bot/commands/userremove.js
+++ b/backend/bot/commands/userremove.js
@@ -1,0 +1,71 @@
+const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder, userMention } = require('discord.js');
+const Wallet = require('../../models/Wallet');
+const Inventory = require('../../models/Inventory');
+const StoreItem = require('../../models/StoreItem');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('userremove')
+    .setDescription('Remove money or items from a user')
+    .addSubcommand(sub =>
+      sub.setName('money')
+        .setDescription('Remove money from a user')
+        .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+        .addNumberOption(opt => opt.setName('amount').setDescription('Amount to remove').setRequired(true))
+    )
+    .addSubcommand(sub =>
+      sub.setName('item')
+        .setDescription('Remove an item from a user')
+        .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
+        .addStringOption(opt => opt.setName('name').setDescription('Item name').setRequired(true).setAutocomplete(true))
+    ),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.Administrator)) {
+      return interaction.reply({ content: '❌ Admins only.', ephemeral: true });
+    }
+
+    const sub = interaction.options.getSubcommand();
+    const user = interaction.options.getUser('user');
+    const discordId = user.id;
+
+    if (sub === 'money') {
+      const amount = interaction.options.getNumber('amount');
+      const wallet = await Wallet.findOne({ discordId }) || await Wallet.create({ discordId });
+      wallet.balance = Math.max(0, wallet.balance - amount);
+      await wallet.save();
+      const embed = new EmbedBuilder()
+        .setColor('Orange')
+        .setTitle('✅ Money Removed')
+        .setDescription(`Removed $${amount.toFixed(2)} from ${userMention(discordId)}'s wallet.`)
+        .addFields({ name: 'New Balance', value: `$${wallet.balance.toFixed(2)}` })
+        .setTimestamp();
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+
+    if (sub === 'item') {
+      const name = interaction.options.getString('name');
+      const inventory = await Inventory.findOne({ discordId });
+      if (!inventory || !inventory.items.length) {
+        return interaction.reply({ content: '❌ Inventory is empty.', ephemeral: true });
+      }
+      const index = inventory.items.findIndex(i => i.name.toLowerCase() === name.toLowerCase());
+      if (index === -1) {
+        return interaction.reply({ content: `❌ Item "${name}" not found in inventory.`, ephemeral: true });
+      }
+      const [removed] = inventory.items.splice(index, 1);
+      await inventory.save();
+      const embed = new EmbedBuilder()
+        .setColor('Orange')
+        .setTitle('📦 Item Removed')
+        .setDescription(`Removed **${removed.name}** from ${userMention(discordId)}'s inventory.`)
+        .setTimestamp();
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+  },
+  async autocomplete(interaction) {
+    if (interaction.options.getSubcommand() !== 'item') return;
+    const focused = interaction.options.getFocused();
+    const items = await StoreItem.find({ name: { $regex: focused, $options: 'i' } }).limit(25);
+    await interaction.respond(items.map(i => ({ name: i.name, value: i.name })));
+  }
+};

--- a/backend/bot/commands/wallet-check.js
+++ b/backend/bot/commands/wallet-check.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder, EmbedBuilder, PermissionsBitField, userMention } = require('discord.js');
+const Civilian = require('../../models/Civilian');
+const Wallet = require('../../models/Wallet');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('wallet-check')
+    .setDescription("Check another user's wallet balance")
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true)),
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionsBitField.Flags.Administrator)) {
+      return interaction.reply({ content: '❌ Admins only.', ephemeral: true });
+    }
+
+    const user = interaction.options.getUser('user');
+    const discordId = user.id;
+
+    const civilian = await Civilian.findOne({ discordId });
+    if (!civilian) {
+      return interaction.reply({ content: '❌ User does not have a registered civilian profile.', ephemeral: true });
+    }
+
+    const wallet = await Wallet.findOne({ discordId }) || await Wallet.create({ discordId });
+
+    const embed = new EmbedBuilder()
+      .setColor('Red')
+      .setTitle('💰 Wallet Balance')
+      .setDescription(`${userMention(discordId)} has **$${wallet.balance.toFixed(2)}** in cash.`)
+      .setTimestamp();
+
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+};

--- a/backend/bot/commands/wallet.js
+++ b/backend/bot/commands/wallet.js
@@ -1,74 +1,27 @@
-const { SlashCommandBuilder, EmbedBuilder, PermissionsBitField, userMention } = require('discord.js');
-const Civilian = require('../../models/Civilian');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const Wallet = require('../../models/Wallet');
+const Civilian = require('../../models/Civilian');
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('wallet')
-    .setDescription('Manage civilian wallet balances')
-    .addSubcommand(sub =>
-      sub.setName('check')
-        .setDescription('Check wallet balance')
-        .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
-    )
-    .addSubcommand(sub =>
-      sub.setName('add')
-        .setDescription('Add wallet funds')
-        .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
-        .addNumberOption(opt => opt.setName('amount').setDescription('Amount to add').setRequired(true))
-    )
-    .addSubcommand(sub =>
-      sub.setName('set')
-        .setDescription('Set wallet balance')
-        .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true))
-        .addNumberOption(opt => opt.setName('amount').setDescription('New balance').setRequired(true))
-    ),
+    .setDescription('View your wallet balance'),
   async execute(interaction) {
-    const sub = interaction.options.getSubcommand();
-    const user = interaction.options.getUser('user');
-    const discordId = user.id;
+    const discordId = interaction.user.id;
 
-    let civilian;
-    try {
-      civilian = await Civilian.findOne({ discordId });
-      if (!civilian || !civilian.discordId) throw new Error('Civilian not found or missing Discord ID.');
-    } catch (err) {
-      console.error('❌ Wallet command error:', err.message);
-      return interaction.reply({ content: '❌ User does not have a registered civilian profile. Please create one before using this command.', ephemeral: true });
+    const civilian = await Civilian.findOne({ discordId });
+    if (!civilian) {
+      return interaction.reply({ content: '❌ You do not have a registered civilian profile.', ephemeral: true });
     }
 
     const wallet = await Wallet.findOne({ discordId }) || await Wallet.create({ discordId });
-    const embed = new EmbedBuilder().setColor('Red').setTimestamp();
 
-    if (sub === 'check') {
-      embed.setTitle('💰 Wallet Balance').setDescription(`${userMention(user.id)} has **$${wallet.balance.toFixed(2)}** in cash.`);
-      return interaction.reply({ embeds: [embed], ephemeral: true });
-    }
+    const embed = new EmbedBuilder()
+      .setColor('Red')
+      .setTitle('💰 Your Wallet Balance')
+      .setDescription(`You have **$${wallet.balance.toFixed(2)}** in cash.`)
+      .setTimestamp();
 
-    if (sub === 'add' || sub === 'set') {
-      if (!interaction.member.permissions.has(PermissionsBitField.Flags.Administrator)) {
-        return interaction.reply({ content: '❌ Admins only.', ephemeral: true });
-      }
-
-      const amount = interaction.options.getNumber('amount');
-
-      if (sub === 'add') {
-        wallet.balance += amount;
-        await wallet.save();
-        embed.setTitle('✅ Wallet Updated')
-          .setDescription(`Added $${amount.toFixed(2)} to ${userMention(user.id)}'s wallet.`)
-          .addFields({ name: 'New Balance', value: `$${wallet.balance.toFixed(2)}` });
-      }
-
-      if (sub === 'set') {
-        wallet.balance = amount;
-        await wallet.save();
-        embed.setTitle('✏️ Wallet Set')
-          .setDescription(`Wallet for ${userMention(user.id)} set to:`)
-          .addFields({ name: 'Balance', value: `$${amount.toFixed(2)}` });
-      }
-
-      return interaction.reply({ embeds: [embed], ephemeral: true });
-    }
+    return interaction.reply({ embeds: [embed], ephemeral: true });
   }
 };

--- a/backend/bot/events/interactionCreate.js
+++ b/backend/bot/events/interactionCreate.js
@@ -13,6 +13,17 @@ module.exports = {
       return handleModalSubmissions(interaction);
     }
 
+    if (interaction.type === InteractionType.ApplicationCommandAutocomplete) {
+      const command = interaction.client.commands.get(interaction.commandName);
+      if (!command || !command.autocomplete) return;
+      try {
+        await command.autocomplete(interaction);
+      } catch (err) {
+        console.error('Autocomplete error:', err);
+      }
+      return;
+    }
+
     if (!interaction.isChatInputCommand()) return;
     const command = interaction.client.commands.get(interaction.commandName);
     if (!command) return;


### PR DESCRIPTION
## Summary
- support autocomplete for `/buy` and `/iteminfo`
- add `/wallet` to show your own balance
- add `/wallet-check` for staff to view others' balance
- add `/useradd` and `/userremove` for managing user wallets/inventory
- add `/store-manage` to edit or delete store items
- handle autocomplete interactions

## Testing
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850d494c9b48330a953806e30205206