### PR TITLE
Add auction command and remove wallet limit

### DIFF
--- a/backend/bot/commands/ebay.js
+++ b/backend/bot/commands/ebay.js
@@ -1,0 +1,77 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+const Inventory = require('../../models/Inventory');
+const Auction = require('../../models/Auction');
+const closeAuction = require('../utils/closeAuction');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ebay')
+    .setDescription('Create an auction for an inventory item')
+    .addStringOption(opt => opt.setName('item').setDescription('Item from your inventory').setRequired(true).setAutocomplete(true))
+    .addNumberOption(opt => opt.setName('startingbid').setDescription('Starting bid').setRequired(true))
+    .addNumberOption(opt => opt.setName('buyout').setDescription('Buyout price').setRequired(true)),
+  async execute(interaction) {
+    const itemName = interaction.options.getString('item');
+    const startingBid = interaction.options.getNumber('startingbid');
+    const buyoutPrice = interaction.options.getNumber('buyout');
+    const discordId = interaction.user.id;
+
+    const inventory = await Inventory.findOne({ discordId });
+    const item = inventory?.items.find(i => i.name.toLowerCase() === itemName.toLowerCase());
+    if (!item) {
+      return interaction.reply({ content: '❌ Item not found in your inventory.', ephemeral: true });
+    }
+
+    if (startingBid <= 0 || buyoutPrice <= 0 || startingBid > buyoutPrice) {
+      return interaction.reply({ content: '❌ Invalid starting bid or buyout price.', ephemeral: true });
+    }
+
+    const auction = await Auction.create({
+      sellerId: discordId,
+      itemName: itemName,
+      startingBid,
+      buyoutPrice,
+      endDate: new Date(Date.now() + 1000 * 60 * 60 * 48)
+    });
+
+    const threadChannelId = process.env.EBAY_THREAD_CHANNEL;
+    const channel = await interaction.client.channels.fetch(threadChannelId);
+    const thread = await channel.threads.create({
+      name: `${interaction.user.username} - ${itemName}`,
+      autoArchiveDuration: 1440
+    });
+
+    const embed = new EmbedBuilder()
+      .setTitle('🛎️ New Auction')
+      .addFields(
+        { name: 'Seller', value: `<@${discordId}>`, inline: true },
+        { name: 'Item', value: itemName, inline: true },
+        { name: 'Starting Bid', value: `$${startingBid}`, inline: true },
+        { name: 'Buyout Price', value: `$${buyoutPrice}`, inline: true },
+        { name: 'Ends', value: `<t:${Math.floor(auction.endDate.getTime() / 1000)}:R>` }
+      )
+      .setColor('Yellow')
+      .setTimestamp();
+
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId(`bid_${auction._id}`).setLabel('Bid').setStyle(ButtonStyle.Primary),
+      new ButtonBuilder().setCustomId(`buyout_${auction._id}`).setLabel('Buyout').setStyle(ButtonStyle.Success)
+    );
+
+    const message = await thread.send({ embeds: [embed], components: [row] });
+    auction.channelId = thread.id;
+    auction.messageId = message.id;
+    await auction.save();
+
+    setTimeout(() => closeAuction(interaction.client, auction._id), 1000 * 60 * 60 * 48);
+
+    return interaction.reply({ content: `✅ Auction created: ${thread.toString()}`, ephemeral: true });
+  },
+  async autocomplete(interaction) {
+    const discordId = interaction.user.id;
+    const inventory = await Inventory.findOne({ discordId });
+    const focused = interaction.options.getFocused();
+    const items = inventory?.items.filter(i => i.name.toLowerCase().includes(focused.toLowerCase())).slice(0,25) || [];
+    await interaction.respond(items.map(i => ({ name: i.name, value: i.name })));
+  }
+};

--- a/backend/bot/events/modalSubmissions.js
+++ b/backend/bot/events/modalSubmissions.js
@@ -3,26 +3,68 @@ const BankAccount = require('../../models/BankAccount');
 const Civilian = require('../../models/Civilian');
 
 module.exports = async function handleModalSubmissions(interaction) {
-  if (!interaction.customId.startsWith('deny_modal_')) return;
+  if (interaction.customId.startsWith('deny_modal_')) {
+    const accountId = interaction.customId.split('deny_modal_')[1];
+    const reason = interaction.fields.getTextInputValue('deny_reason');
 
-  const accountId = interaction.customId.split('deny_modal_')[1];
-  const reason = interaction.fields.getTextInputValue('deny_reason');
+    const account = await BankAccount.findById(accountId);
+    if (!account) return interaction.reply({ content: '❌ Account not found.', ephemeral: true });
 
-  const account = await BankAccount.findById(accountId);
-  if (!account) return interaction.reply({ content: '❌ Account not found.', ephemeral: true });
+    const civilian = await Civilian.findById(account.civilianId);
+    if (!civilian) return interaction.reply({ content: '❌ Civilian not found.', ephemeral: true });
 
-  const civilian = await Civilian.findById(account.civilianId);
-  if (!civilian) return interaction.reply({ content: '❌ Civilian not found.', ephemeral: true });
+    const user = await interaction.client.users.fetch(civilian.discordId);
+    const embed = new EmbedBuilder()
+      .setTitle('❌ Bank Account Denied')
+      .setDescription(`Your **${account.accountType}** account (#${account.accountNumber}) was denied.`)
+      .addFields({ name: 'Reason', value: reason })
+      .setColor('Red')
+      .setTimestamp();
 
-  const user = await interaction.client.users.fetch(civilian.discordId);
-  const embed = new EmbedBuilder()
-    .setTitle('❌ Bank Account Denied')
-    .setDescription(`Your **${account.accountType}** account (#${account.accountNumber}) was denied.`)
-    .addFields({ name: 'Reason', value: reason })
-    .setColor('Red')
-    .setTimestamp();
+    await user.send({ embeds: [embed] }).catch(err => console.warn('Failed to DM user:', err));
+    await BankAccount.findByIdAndDelete(accountId);
+    return interaction.reply({ content: '✅ Account denied and user notified.', ephemeral: true });
+  }
 
-  await user.send({ embeds: [embed] }).catch(err => console.warn('Failed to DM user:', err));
-  await BankAccount.findByIdAndDelete(accountId);
-  return interaction.reply({ content: '✅ Account denied and user notified.', ephemeral: true });
+  if (interaction.customId.startsWith('bid_modal_')) {
+    const auctionId = interaction.customId.split('bid_modal_')[1];
+    const amount = parseFloat(interaction.fields.getTextInputValue('bid_amount'));
+    const Auction = require('../../models/Auction');
+    const Wallet = require('../../models/Wallet');
+
+    const auction = await Auction.findById(auctionId);
+    if (!auction || auction.status !== 'open') {
+      return interaction.reply({ content: '❌ Auction is closed.', ephemeral: true });
+    }
+
+    const minBid = auction.highestBid?.amount ? auction.highestBid.amount + 1 : auction.startingBid;
+    if (amount < minBid) {
+      return interaction.reply({ content: `❌ Bid must be at least $${minBid}.`, ephemeral: true });
+    }
+
+    const wallet = await Wallet.findOne({ discordId: interaction.user.id }) || await Wallet.create({ discordId: interaction.user.id });
+    if (wallet.balance < amount) {
+      return interaction.reply({ content: '❌ Insufficient funds for bid.', ephemeral: true });
+    }
+
+    auction.highestBid = { amount, bidderId: interaction.user.id };
+    await auction.save();
+
+    const channel = await interaction.client.channels.fetch(auction.channelId).catch(() => null);
+    const message = channel ? await channel.messages.fetch(auction.messageId).catch(() => null) : null;
+    if (message) {
+      const updatedEmbed = EmbedBuilder.from(message.embeds[0])
+        .setFields(
+          { name: 'Seller', value: `<@${auction.sellerId}>`, inline: true },
+          { name: 'Item', value: auction.itemName, inline: true },
+          { name: 'Starting Bid', value: `$${auction.startingBid}`, inline: true },
+          { name: 'Buyout Price', value: `$${auction.buyoutPrice}`, inline: true },
+          { name: 'Highest Bid', value: `$${amount} by <@${interaction.user.id}>` },
+          { name: 'Ends', value: `<t:${Math.floor(auction.endDate.getTime() / 1000)}:R>` }
+        );
+      await message.edit({ embeds: [updatedEmbed] });
+    }
+
+    return interaction.reply({ content: '✅ Bid placed.', ephemeral: true });
+  }
 };

--- a/backend/bot/utils/closeAuction.js
+++ b/backend/bot/utils/closeAuction.js
@@ -1,0 +1,50 @@
+const { EmbedBuilder } = require('discord.js');
+const Auction = require('../../models/Auction');
+const Wallet = require('../../models/Wallet');
+const Inventory = require('../../models/Inventory');
+const logError = require('./logError');
+
+async function closeAuction(client, auctionId) {
+  try {
+    const auction = await Auction.findById(auctionId);
+    if (!auction || auction.status === 'closed') return;
+
+    auction.status = 'closed';
+    await auction.save();
+
+    const channel = await client.channels.fetch(auction.channelId).catch(() => null);
+    const message = channel ? await channel.messages.fetch(auction.messageId).catch(() => null) : null;
+
+    if (auction.highestBid && auction.highestBid.bidderId) {
+      const sellerWallet = await Wallet.findOne({ discordId: auction.sellerId }) || await Wallet.create({ discordId: auction.sellerId });
+      const buyerWallet = await Wallet.findOne({ discordId: auction.highestBid.bidderId }) || await Wallet.create({ discordId: auction.highestBid.bidderId });
+
+      if (buyerWallet.balance >= auction.highestBid.amount) {
+        buyerWallet.balance -= auction.highestBid.amount;
+        sellerWallet.balance += auction.highestBid.amount;
+        await Promise.all([buyerWallet.save(), sellerWallet.save()]);
+
+        await Inventory.findOneAndUpdate(
+          { discordId: auction.sellerId },
+          { $pull: { items: { name: auction.itemName } } }
+        );
+        await Inventory.findOneAndUpdate(
+          { discordId: auction.highestBid.bidderId },
+          { $push: { items: { name: auction.itemName, price: auction.highestBid.amount, purchasedAt: new Date() } } },
+          { upsert: true }
+        );
+      }
+    }
+
+    if (message) {
+      const embed = EmbedBuilder.from(message.embeds[0])
+        .setFooter({ text: 'Auction closed.' })
+        .setColor('Grey');
+      await message.edit({ embeds: [embed], components: [] });
+    }
+  } catch (err) {
+    logError('Close auction', err);
+  }
+}
+
+module.exports = closeAuction;

--- a/backend/models/Auction.js
+++ b/backend/models/Auction.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const AuctionSchema = new mongoose.Schema({
+  sellerId: { type: String, required: true },
+  itemName: { type: String, required: true },
+  startingBid: { type: Number, required: true },
+  buyoutPrice: { type: Number, required: true },
+  highestBid: {
+    amount: Number,
+    bidderId: String
+  },
+  status: { type: String, enum: ['open', 'closed'], default: 'open' },
+  endDate: { type: Date, required: true },
+  channelId: String,
+  messageId: String,
+}, { timestamps: true });
+
+module.exports = mongoose.model('Auction', AuctionSchema);

--- a/frontend/src/pages/BankDashboard.jsx
+++ b/frontend/src/pages/BankDashboard.jsx
@@ -115,10 +115,6 @@ const [withdrawError, setWithdrawError] = useState("");
       return;
     }
   
-    if (walletBalance > 50000) {
-      setDepositError("You are carrying too much cash. Please open a bank account.");
-      return;
-    }
   
     try {
       await api.post("/api/bank/deposit", {


### PR DESCRIPTION
## Summary
- remove 50k wallet limit check in deposit flow
- add auction data model
- add `/ebay` command for auctioning inventory items
- add auction close utility and interaction handlers

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*
- `npm test --silent` in backend (shows no tests)


------
https://chatgpt.com/codex/tasks/task_e_6851f28ffcc8833084648e955163839c