### PR TITLE
Improve license role assignment

### DIFF
--- a/backend/bot/utils/assignLicenseRole.js
+++ b/backend/bot/utils/assignLicenseRole.js
@@ -1,18 +1,40 @@
+// Map of license types to Discord role IDs. Environment variables
+// can override these defaults if provided.
 const ROLE_MAP = {
-  "Standard Driver's License": process.env.ROLE_DRIVER,
-  "Motorcycle License": process.env.ROLE_MOTORCYCLE,
-  "CDL Class A": process.env.ROLE_CDL_A,
-  "CDL Class B": process.env.ROLE_CDL_B,
+  "Standard Driver's License":
+    process.env.ROLE_DRIVER || "1372243631766896680",
+  "Motorcycle License":
+    process.env.ROLE_MOTORCYCLE || "1372243630613598258",
+  "CDL Class A": process.env.ROLE_CDL_A || "1370192296162885672",
+  "CDL Class B": process.env.ROLE_CDL_B || "1370192299195236352",
 };
 const logError = require('./logError');
 
 async function assignLicenseRole(client, discordId, licenseType) {
   try {
-    const guild = await client.guilds.fetch(process.env.DISCORD_GUILD_ID);
+    let guildId = process.env.DISCORD_GUILD_ID;
+    let guild;
+    if (guildId) {
+      guild = client.guilds.cache.get(guildId);
+      if (!guild) guild = await client.guilds.fetch(guildId);
+    } else {
+      // Fallback to the first guild the bot is in if no env var provided
+      console.warn('⚠️ DISCORD_GUILD_ID env var not set, using first available guild');
+      guild = client.guilds.cache.first();
+      guildId = guild?.id;
+    }
+    if (!guild) throw new Error('Guild not found');
+
     const member = await guild.members.fetch(discordId);
+    if (!member) throw new Error(`Member ${discordId} not found`);
+
     const roleId = ROLE_MAP[licenseType];
     if (!roleId) throw new Error(`No role ID mapped for ${licenseType}`);
-    await member.roles.add(roleId);
+
+    const role = guild.roles.cache.get(roleId);
+    if (!role) throw new Error(`Role ${roleId} not found in guild`);
+
+    await member.roles.add(role);
     return true;
   } catch (err) {
     logError('Assign license role', err);

--- a/backend/routes/civilians.js
+++ b/backend/routes/civilians.js
@@ -128,11 +128,17 @@ router.post("/:id/add-license", ensureAuth, async (req, res) => {
     const licenseType = req.body.license;
     const discordId = req.user?.discordId;
 
+    // Map license names to Discord role IDs. Allow environment variables to
+    // override the defaults.
     const LICENSE_ROLE_MAP = {
-      "Class C - Standard Drivers License": process.env.ROLE_DRIVER,
-      "Class M - Motorcycle License": process.env.ROLE_MOTORCYCLE,
-      "Class A - CDL Class A License": process.env.ROLE_CDL_A,
-      "Class B - CDL Class B License": process.env.ROLE_CDL_B,
+      "Class C - Standard Drivers License":
+        process.env.ROLE_DRIVER || "1372243631766896680",
+      "Class M - Motorcycle License":
+        process.env.ROLE_MOTORCYCLE || "1372243630613598258",
+      "Class A - CDL Class A License":
+        process.env.ROLE_CDL_A || "1370192296162885672",
+      "Class B - CDL Class B License":
+        process.env.ROLE_CDL_B || "1370192299195236352",
     };
 
     const requiredRoleId = LICENSE_ROLE_MAP[licenseType];

--- a/backend/routes/licenses.js
+++ b/backend/routes/licenses.js
@@ -40,11 +40,11 @@ router.post("/save-test", ensureAuth, async (req, res) => {
 
     // Attempt to assign license role if passed
     if (passed) {
-      try {
-        await assignLicenseRole(user.discordId, licenseType);
+      const success = await assignLicenseRole(user.discordId, licenseType);
+      if (success) {
         console.log(`✅ Assigned ${licenseType} role to ${user.username}`);
-      } catch (roleErr) {
-        console.error("❌ Failed to assign license role:", roleErr);
+      } else {
+        console.error(`❌ Failed to assign ${licenseType} role to ${user.username}`);
       }
     }
 

--- a/frontend/src/components/LicenseExamSelector.jsx
+++ b/frontend/src/components/LicenseExamSelector.jsx
@@ -6,7 +6,6 @@ const LicenseExamSelector = ({ onSelect }) => {
     "Motorcycle License",
     "CDL Class A",
     "CDL Class B",
-    "CDL Class C",
   ];
 
   return (

--- a/frontend/src/data/dmvExamQuestions.js
+++ b/frontend/src/data/dmvExamQuestions.js
@@ -208,58 +208,6 @@ export const DMV_EXAMS = {
         options: ["Only on hills", "Whenever parked", "Never", "When stopped in traffic"],
         answer: "Whenever parked"
       }
-    ],
-    "CDL Class C": [
-      {
-        question: "Class C license is for:",
-        options: ["Vehicles transporting 16+ passengers or hazmat", "Motorcycles", "Emergency vehicles", "Trailers"],
-        answer: "Vehicles transporting 16+ passengers or hazmat"
-      },
-      {
-        question: "When should you check mirrors?",
-        options: ["Only when parked", "Every 5-8 seconds", "Only before lane changes", "Only when reversing"],
-        answer: "Every 5-8 seconds"
-      },
-      {
-        question: "What is a blind spot?",
-        options: ["Partially blocked mirror", "Area not visible in mirrors", "Driver's side", "Passenger area"],
-        answer: "Area not visible in mirrors"
-      },
-      {
-        question: "Who is responsible for cargo securement?",
-        options: ["Warehouse staff", "Loader", "Driver", "Manager"],
-        answer: "Driver"
-      },
-      {
-        question: "What are reflective triangles used for?",
-        options: ["Decoration", "Visibility during breakdown", "Police signals", "Accident scene"],
-        answer: "Visibility during breakdown"
-      },
-      {
-        question: "How should you signal lane changes?",
-        options: ["Flash lights", "Turn signal, check mirrors, blind spot", "Honk", "Brake lights"],
-        answer: "Turn signal, check mirrors, blind spot"
-      },
-      {
-        question: "What’s the best way to handle distractions?",
-        options: ["Multitask", "Minimize them before driving", "Handle while moving", "Ignore"],
-        answer: "Minimize them before driving"
-      },
-      {
-        question: "When should you use low beams?",
-        options: ["Always", "In fog or snow", "Never", "Only at night"],
-        answer: "In fog or snow"
-      },
-      {
-        question: "Which vehicles require Class C CDL?",
-        options: ["All passenger cars", "Vehicles under 10,000 lbs", "Passenger vans with 16+ or hazmat", "Buses only"],
-        answer: "Passenger vans with 16+ or hazmat"
-      },
-      {
-        question: "What to do during a tire blowout?",
-        options: ["Brake hard", "Accelerate", "Grip wheel and steer straight", "Swerve left"],
-        answer: "Grip wheel and steer straight"
-      }
     ]
   };
   


### PR DESCRIPTION
## Summary
- enhance license role assignment with env var checks and detailed errors
- log role assignment success only if added
- remove obsolete Class C exam
- show only four exam types
- fallback to the first guild when DISCORD_GUILD_ID is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852295dde148330a26a99cc1e79cedc