### PR TITLE
Fix search dropdown API URL

### DIFF
--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1,7 +1,17 @@
 import axios from "axios";
 
+// Allow overriding the API base URL via environment variable. If none is
+// provided we assume a development setup when running on localhost and fall
+// back to the production API for any other host. This avoids 400/500 errors
+// when the frontend cannot reach the backend because the URL is incorrect.
+
+const defaultBaseURL =
+  window.location.hostname === "localhost"
+    ? "http://localhost:8080"
+    : "https://api.primerpcad.com";
+
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_BASE_URL || "https://api.primerpcad.com",
+  baseURL: process.env.REACT_APP_API_BASE_URL || defaultBaseURL,
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- use `localhost` API server when running the frontend locally

## Testing
- `npm test` *(fails: react-app-rewired not found; dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856092e620083308d9955931b67e197