### PR TITLE
Improve API URL detection

### DIFF
--- a/frontend/src/pages/LoginGate.jsx
+++ b/frontend/src/pages/LoginGate.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useUser } from "../hooks/useUser";
+import { defaultBaseURL } from "../utils/axios";
 
 const LoginGate = () => {
   const { discordId, loading } = useUser();
@@ -13,8 +14,7 @@ const LoginGate = () => {
   }, [discordId, loading, navigate]);
 
   const handleLogin = () => {
-    const baseUrl =
-      process.env.REACT_APP_API_BASE_URL || "http://localhost:8080";
+    const baseUrl = process.env.REACT_APP_API_BASE_URL || defaultBaseURL;
     try {
       window.location.href = `${baseUrl}/auth/discord`;
     } catch (err) {

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1,7 +1,17 @@
 import axios from "axios";
 
+// Allow overriding the API base URL via environment variable. If none is
+// provided we assume a development setup when running locally (localhost or
+// 127.x.x.x) and fall back to the production API for any other host. This avoids
+// 400/500 errors when the frontend cannot reach the backend because the URL is
+// incorrect.
+
+export const defaultBaseURL = /^localhost$|^127\./.test(window.location.hostname)
+  ? "http://localhost:8080"
+  : "https://api.primerpcad.com";
+
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_BASE_URL || "https://api.primerpcad.com",
+  baseURL: process.env.REACT_APP_API_BASE_URL || defaultBaseURL,
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- export `defaultBaseURL` helper that detects localhost or 127.x addresses
- use the new constant in LoginGate

## Testing
- `npm test --silent --runInBand`
- `cd frontend && npm test --silent --runInBand` *(fails: react-app-rewired not found; dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856092e620083308d9955931b67e197