### PR TITLE
Fix search database hook errors

### DIFF
--- a/frontend/src/pages/police/SearchDatabase.jsx
+++ b/frontend/src/pages/police/SearchDatabase.jsx
@@ -82,12 +82,8 @@ export default function SearchDatabase() {
 
   const handleSearch = async () => {
     try {
-      setCivilian(null);
-      setVehicleResult(null);
-      setWeaponResult(null);
       setSearchType(null);
       setResults([]);
-      setShowFullCivilian(false);
 
       const res = await api.get("/api/search", {
         params: {


### PR DESCRIPTION
## Summary
- remove leftover state resets for undefined hooks in `SearchDatabase`

## Testing
- `npm run build` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561401e3108330aad447d7178d7e86