### PR TITLE
Fix search database build error

### DIFF
--- a/frontend/src/pages/police/SearchDatabase.jsx
+++ b/frontend/src/pages/police/SearchDatabase.jsx
@@ -2,6 +2,10 @@
 import React, { useState, useEffect, Fragment } from "react";
 import api from "../../utils/axios";
 
+// The build previously failed because this component attempted to
+// reset state hooks that were never defined. Those lines were removed
+// so ESLint no longer reports `no-undef` errors.
+
 import { Combobox, Transition } from "@headlessui/react";
 
 export default function SearchDatabase() {


### PR DESCRIPTION
## Summary
- clarify history of removed hook resets in `SearchDatabase.jsx`

## Testing
- `npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_685614faaf0483308647171937b49e80