### PR TITLE
Add demand-based investment price adjustments

### DIFF
--- a/backend/bot/commands/invest.js
+++ b/backend/bot/commands/invest.js
@@ -52,6 +52,8 @@ module.exports = {
         holding.avgPrice = totalCost / holding.quantity;
         await holding.save();
       }
+      asset.netDemand += quantity;
+      await asset.save();
       await wallet.save();
       return interaction.reply({ content: `✅ Bought ${quantity} ${identifier} for $${cost}.`, ephemeral: true });
     } else {
@@ -67,6 +69,8 @@ module.exports = {
       const revenue = asset.price * quantity;
       holding.quantity -= quantity;
       wallet.balance += revenue;
+      asset.netDemand -= quantity;
+      await asset.save();
       await wallet.save();
       if (holding.quantity <= 0) {
         await InvestmentHolding.deleteOne({ _id: holding._id });

--- a/backend/bot/utils/updateInvestments.js
+++ b/backend/bot/utils/updateInvestments.js
@@ -27,6 +27,11 @@ async function updatePrices(client) {
         changePercent += asset.eventModifier * asset.risk * 2;
         asset.eventModifier = 0;
       }
+      // apply demand modifier from user trading
+      if (asset.netDemand) {
+        changePercent += asset.netDemand * asset.risk * 0.05;
+        asset.netDemand = 0;
+      }
 
       const newPrice = Math.max(1, Math.round(asset.price * (1 + changePercent / 100)));
       asset.price = newPrice;

--- a/backend/models/InvestmentAsset.js
+++ b/backend/models/InvestmentAsset.js
@@ -6,7 +6,8 @@ const InvestmentAssetSchema = new mongoose.Schema({
   category: { type: String, required: true },
   risk: { type: Number, required: true },
   price: { type: Number, default: 100 },
-  eventModifier: { type: Number, default: 0 }
+  eventModifier: { type: Number, default: 0 },
+  netDemand: { type: Number, default: 0 } // tracks net buys minus sells since last update
 }, { timestamps: true });
 
 module.exports = mongoose.model('InvestmentAsset', InvestmentAssetSchema);


### PR DESCRIPTION
## Summary
- track net buy/sell activity on investment assets
- factor user demand into scheduled price updates
- record buy/sell demand in the invest command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf0944388330b087eae7b0adb5ea