### PR TITLE
Implement credit and loan system

### DIFF
--- a/backend/bot/commands/credit.js
+++ b/backend/bot/commands/credit.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { getCredit } = require('../services/loanService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('credit')
+    .setDescription('Credit system commands')
+    .addSubcommand(sub =>
+      sub.setName('check').setDescription('Check your credit score')
+    ),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'check') {
+      const profile = await getCredit(interaction.user.id);
+      const embed = new EmbedBuilder()
+        .setTitle('💳 Credit Score')
+        .setColor('Blue')
+        .setDescription(`Your credit score is **${profile.score}**.`)
+        .setTimestamp();
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+  }
+};

--- a/backend/bot/commands/loan.js
+++ b/backend/bot/commands/loan.js
@@ -1,0 +1,54 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const Loan = require('../../models/Loan');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('loan')
+    .setDescription('Loan system commands')
+    .addSubcommand(sub => sub.setName('panel').setDescription('Open the loan application panel'))
+    .addSubcommand(sub => sub.setName('status').setDescription('View your active loans'))
+    .addSubcommand(sub => sub.setName('history').setDescription('View your loan history')),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'panel') {
+      const embed = new EmbedBuilder()
+        .setTitle('📄 Apply for a Loan')
+        .setColor('Blue')
+        .setDescription('Available loan type: **Personal**\nApplying affects your credit score.');
+      const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('loan_apply').setLabel('Apply Now').setStyle(ButtonStyle.Primary)
+      );
+      return interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
+    }
+
+    if (sub === 'status') {
+      const loans = await Loan.find({ userId: interaction.user.id, status: 'active' });
+      const embed = new EmbedBuilder()
+        .setTitle('📑 Active Loans')
+        .setColor('Blue');
+      if (!loans.length) embed.setDescription('You have no active loans.');
+      for (const loan of loans) {
+        embed.addFields({
+          name: `Loan ${loan._id.toString()}`,
+          value: `Amount: $${loan.amount}\nWeekly: $${loan.weeklyPayment}\nPayments Left: ${loan.paymentsRemaining}\nStrikes: ${loan.strikes}`
+        });
+      }
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+
+    if (sub === 'history') {
+      const loans = await Loan.find({ userId: interaction.user.id, status: { $ne: 'active' } });
+      const embed = new EmbedBuilder()
+        .setTitle('📜 Loan History')
+        .setColor('Blue');
+      if (!loans.length) embed.setDescription('No past loans.');
+      for (const loan of loans) {
+        embed.addFields({
+          name: `Loan ${loan._id.toString()}`,
+          value: `Amount: $${loan.amount}\nStatus: ${loan.status}\nStrikes: ${loan.strikes}`
+        });
+      }
+      return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+  }
+};

--- a/backend/bot/events/buttonInteractions.js
+++ b/backend/bot/events/buttonInteractions.js
@@ -211,4 +211,62 @@ module.exports = async function handleButtonInteractions(interaction) {
       );
     return interaction.showModal(modal);
   }
+
+  if (customId === 'loan_apply') {
+    const modal = new ModalBuilder()
+      .setCustomId('loan_application')
+      .setTitle('Loan Application')
+      .addComponents(
+        new ActionRowBuilder().addComponents(
+          new TextInputBuilder()
+            .setCustomId('loan_amount')
+            .setLabel('Loan Amount')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true)
+        ),
+        new ActionRowBuilder().addComponents(
+          new TextInputBuilder()
+            .setCustomId('loan_term')
+            .setLabel('Loan Term (Weeks)')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true)
+        ),
+        new ActionRowBuilder().addComponents(
+          new TextInputBuilder()
+            .setCustomId('loan_purpose')
+            .setLabel('Purpose of Loan')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true)
+        ),
+        new ActionRowBuilder().addComponents(
+          new TextInputBuilder()
+            .setCustomId('loan_terms')
+            .setLabel('Agree to Terms? (Yes/No)')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true)
+        )
+      );
+    return interaction.showModal(modal);
+  }
+
+  if (customId.startsWith('loan_sign_')) {
+    const [, amt, term, rate] = customId.split('_');
+    const { createLoan } = require('../services/loanService');
+    const amount = parseFloat(amt);
+    const termWeeks = parseInt(term);
+    const interest = parseFloat(rate);
+    await createLoan(interaction.client, interaction.user.id, amount, termWeeks, interest);
+    await interaction.update({ content: '✅ Loan signed and stored.', embeds: [], components: [] });
+  }
+
+  if (customId === 'loan_decline') {
+    return interaction.update({ content: '❌ Loan declined.', embeds: [], components: [] });
+  }
+
+  if (customId.startsWith('loan_pay_')) {
+    const loanId = customId.split('loan_pay_')[1];
+    const { payLoan } = require('../services/loanService');
+    await payLoan(interaction.client, loanId);
+    await interaction.update({ content: '✅ Payment received.', embeds: [], components: [] });
+  }
 };

--- a/backend/bot/events/modalSubmissions.js
+++ b/backend/bot/events/modalSubmissions.js
@@ -67,4 +67,69 @@ module.exports = async function handleModalSubmissions(interaction) {
 
     return interaction.reply({ content: '✅ Bid placed.', ephemeral: true });
   }
+
+  if (interaction.customId === 'loan_application') {
+    const amount = parseFloat(interaction.fields.getTextInputValue('loan_amount'));
+    const termWeeks = parseInt(interaction.fields.getTextInputValue('loan_term'));
+    const agree = interaction.fields.getTextInputValue('loan_terms').toLowerCase();
+    const purpose = interaction.fields.getTextInputValue('loan_purpose');
+
+    if (agree !== 'yes') {
+      return interaction.reply({ content: '❌ You must agree to the terms.', ephemeral: true });
+    }
+
+    const { getCredit } = require('../services/loanService');
+    const profile = await getCredit(interaction.user.id);
+
+    const getRate = score => {
+      if (score <= 579) return 25;
+      if (score <= 669) return 18;
+      if (score <= 739) return 12;
+      if (score <= 799) return 6;
+      return 3;
+    };
+
+    if (profile.score < 580) {
+      const warn = new EmbedBuilder()
+        .setTitle('Collateral Required')
+        .setDescription('Your credit score is below 580. Collateral will be required.')
+        .setColor('Orange');
+      await interaction.reply({ embeds: [warn], ephemeral: true });
+      const sendFinancialLogEmbed = require('../utils/sendFinancialLogEmbed');
+      const log = EmbedBuilder.from(warn)
+        .setTitle('⚠️ Loan Collateral Needed')
+        .addFields({ name: 'User', value: `<@${interaction.user.id}>` }, { name: 'Purpose', value: purpose });
+      await sendFinancialLogEmbed(interaction.client, log);
+      return;
+    }
+
+    const rate = getRate(profile.score);
+    const total = amount * (1 + rate / 100);
+    const weeklyPayment = Number((total / termWeeks).toFixed(2));
+
+    const contract = new EmbedBuilder()
+      .setTitle('📜 Loan Contract')
+      .setColor('Blue')
+      .addFields(
+        { name: 'Loan Type', value: 'Personal', inline: true },
+        { name: 'Loan Amount', value: `$${amount}`, inline: true },
+        { name: 'Term Length', value: `${termWeeks} weeks`, inline: true },
+        { name: 'Interest %', value: `${rate}%`, inline: true },
+        { name: 'Total Repayment', value: `$${total.toFixed(2)}`, inline: true },
+        { name: 'Weekly Payment', value: `$${weeklyPayment}`, inline: true }
+      );
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`loan_sign_${amount}_${termWeeks}_${rate}`)
+        .setLabel('Sign Loan')
+        .setStyle(ButtonStyle.Success),
+      new ButtonBuilder()
+        .setCustomId('loan_decline')
+        .setLabel('Decline')
+        .setStyle(ButtonStyle.Danger)
+    );
+
+    await interaction.reply({ content: '📑 Contract sent to your DMs.', ephemeral: true });
+    await interaction.user.send({ embeds: [contract], components: [row] }).catch(() => null);
+  }
 };

--- a/backend/bot/index.js
+++ b/backend/bot/index.js
@@ -44,6 +44,13 @@ mongoose.connect(process.env.MONGO_URI)
   .then(() => console.log('✅ MongoDB connected'))
   .catch(err => console.error('❌ MongoDB connection error:', err));
 
+const { schedulePayment } = require('./services/loanService');
+mongoose.connection.on('open', async () => {
+  const Loan = require('../models/Loan');
+  const loans = await Loan.find({ status: 'active' });
+  for (const loan of loans) schedulePayment(client, loan);
+});
+
 client.login(process.env.DISCORD_BOT_TOKEN);
 
 // Utils
@@ -65,5 +72,6 @@ module.exports = {
   formatStorePage,
   scheduleFineCheck: (...args) => scheduleFineCheckUtil(client, ...args),
   sendClockEmbed: (...args) => sendClockEmbedUtil(client, ...args),
-  sendFinancialLogEmbed: (...args) => sendFinancialLogEmbedUtil(client, ...args)
+  sendFinancialLogEmbed: (...args) => sendFinancialLogEmbedUtil(client, ...args),
+  scheduleLoanPayment: (...args) => schedulePayment(client, ...args)
 };

--- a/backend/bot/services/loanService.js
+++ b/backend/bot/services/loanService.js
@@ -1,0 +1,122 @@
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const CreditProfile = require('../../models/CreditProfile');
+const Loan = require('../../models/Loan');
+const sendFinancialLogEmbed = require('../utils/sendFinancialLogEmbed');
+
+async function getCredit(discordId) {
+  let profile = await CreditProfile.findOne({ discordId });
+  if (!profile) profile = await CreditProfile.create({ discordId });
+  return profile;
+}
+
+async function adjustCredit(client, discordId, delta, reason) {
+  const profile = await getCredit(discordId);
+  profile.score = Math.max(300, Math.min(850, profile.score + delta));
+  await profile.save();
+
+  const embed = new EmbedBuilder()
+    .setTitle('💳 Credit Score Updated')
+    .setColor(delta >= 0 ? 'Green' : 'Red')
+    .setDescription(`<@${discordId}> ${delta >= 0 ? 'gained' : 'lost'} **${Math.abs(delta)}** credit points.`)
+    .addFields({ name: 'New Score', value: String(profile.score) }, { name: 'Reason', value: reason })
+    .setTimestamp();
+  await sendFinancialLogEmbed(client, embed);
+  return profile;
+}
+
+async function createLoan(client, discordId, amount, termWeeks, interest) {
+  const total = amount * (1 + interest / 100);
+  const weeklyPayment = Number((total / termWeeks).toFixed(2));
+  const profile = await getCredit(discordId);
+  const loan = await Loan.create({
+    userId: discordId,
+    amount,
+    interest,
+    weeklyPayment,
+    termWeeks,
+    paymentsRemaining: termWeeks,
+    creditScoreAtApproval: profile.score,
+    nextPaymentDue: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  });
+
+  await adjustCredit(client, discordId, 15, 'Loan approved');
+  schedulePayment(client, loan);
+
+  const embed = new EmbedBuilder()
+    .setTitle('✅ Loan Signed')
+    .setColor('Green')
+    .addFields(
+      { name: 'User', value: `<@${discordId}>`, inline: true },
+      { name: 'Amount', value: `$${amount}` , inline: true },
+      { name: 'Term', value: `${termWeeks} weeks`, inline: true },
+      { name: 'Interest', value: `${interest}%`, inline: true }
+    )
+    .setTimestamp();
+  await sendFinancialLogEmbed(client, embed);
+  return loan;
+}
+
+async function payLoan(client, loanId) {
+  const loan = await Loan.findById(loanId);
+  if (!loan || loan.status !== 'active') return null;
+  loan.paymentsRemaining -= 1;
+  loan.nextPaymentDue = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  await adjustCredit(client, loan.userId, 10, 'Loan payment received');
+  if (loan.paymentsRemaining <= 0) {
+    loan.status = 'paid';
+    await adjustCredit(client, loan.userId, 30, 'Loan fully repaid');
+  }
+  await loan.save();
+  if (loan.status === 'active') schedulePayment(client, loan);
+  return loan;
+}
+
+async function markMissedPayment(client, loan) {
+  loan.strikes += 1;
+  await adjustCredit(client, loan.userId, -25, 'Missed loan payment');
+  if (loan.strikes >= 3) {
+    loan.status = 'defaulted';
+  }
+  await loan.save();
+  if (loan.status === 'active') {
+    loan.nextPaymentDue = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    schedulePayment(client, loan);
+  }
+}
+
+function schedulePayment(client, loan) {
+  const delay = loan.nextPaymentDue.getTime() - Date.now();
+  setTimeout(async () => {
+    const fresh = await Loan.findById(loan._id);
+    if (!fresh || fresh.status !== 'active') return;
+    const user = await client.users.fetch(fresh.userId).catch(() => null);
+    if (!user) return;
+
+    const embed = new EmbedBuilder()
+      .setTitle('💰 Loan Payment Due')
+      .setColor('Blue')
+      .setDescription(`You owe **$${fresh.weeklyPayment}**. Click **Pay** within 24h to avoid penalties.`)
+      .addFields({ name: 'Payments Left', value: String(fresh.paymentsRemaining) });
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId(`loan_pay_${fresh._id}`).setLabel('Pay').setStyle(ButtonStyle.Success)
+    );
+    await user.send({ embeds: [embed], components: [row] }).catch(() => null);
+
+    setTimeout(async () => {
+      const check = await Loan.findById(fresh._id);
+      if (!check || check.status !== 'active') return;
+      if (check.nextPaymentDue > Date.now() - 6.5 * 24 * 60 * 60 * 1000) return; // payment made
+      if (check.paymentsRemaining === fresh.paymentsRemaining) {
+        await markMissedPayment(client, check);
+      }
+    }, 24 * 60 * 60 * 1000);
+  }, Math.max(0, delay));
+}
+
+module.exports = {
+  getCredit,
+  adjustCredit,
+  createLoan,
+  payLoan,
+  schedulePayment,
+};

--- a/backend/models/CreditProfile.js
+++ b/backend/models/CreditProfile.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const CreditProfileSchema = new mongoose.Schema({
+  discordId: { type: String, required: true, unique: true },
+  score: { type: Number, default: 600 }
+}, { timestamps: true });
+
+module.exports = mongoose.model('CreditProfile', CreditProfileSchema);

--- a/backend/models/Loan.js
+++ b/backend/models/Loan.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const LoanSchema = new mongoose.Schema({
+  userId: { type: String, required: true },
+  amount: { type: Number, required: true },
+  interest: { type: Number, required: true },
+  weeklyPayment: { type: Number, required: true },
+  termWeeks: { type: Number, required: true },
+  paymentsRemaining: { type: Number, required: true },
+  creditScoreAtApproval: { type: Number, required: true },
+  strikes: { type: Number, default: 0 },
+  nextPaymentDue: { type: Date, required: true },
+  createdAt: { type: Date, default: Date.now },
+  status: { type: String, enum: ['active', 'paid', 'defaulted'], default: 'active' }
+});
+
+module.exports = mongoose.model('Loan', LoanSchema);


### PR DESCRIPTION
## Summary
- track credit in `CreditProfile` model
- add `Loan` model and loan management service
- expose `/credit check` command
- add `/loan panel`, `/loan status` and `/loan history` commands
- handle loan buttons & modal submissions
- schedule active loans when the bot starts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686814a5b1448330a8c2a2076cce7068