### PR TITLE
Refactor loan workflow

### DIFF
--- a/backend/bot/commands/loan.js
+++ b/backend/bot/commands/loan.js
@@ -5,16 +5,17 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('loan')
     .setDescription('Loan system commands')
-    .addSubcommand(sub => sub.setName('panel').setDescription('Open the loan application panel'))
-    .addSubcommand(sub => sub.setName('status').setDescription('View your active loans'))
-    .addSubcommand(sub => sub.setName('history').setDescription('View your loan history')),
+  .addSubcommand(sub => sub.setName('panel').setDescription('Open the loan application panel'))
+  .addSubcommand(sub => sub.setName('status').setDescription('View your active loans'))
+  .addSubcommand(sub => sub.setName('history').setDescription('View your loan history'))
+  .addSubcommand(sub => sub.setName('pay').setDescription('Send payment panel')),
   async execute(interaction) {
     const sub = interaction.options.getSubcommand();
     if (sub === 'panel') {
       const embed = new EmbedBuilder()
         .setTitle('📄 Apply for a Loan')
         .setColor('Blue')
-        .setDescription('Available loan type: **Personal**\nApplying affects your credit score.');
+        .setDescription('Available loan types: **Personal**, **Home**, **Auto**, **Business**\nApplying affects your credit score.');
       const row = new ActionRowBuilder().addComponents(
         new ButtonBuilder().setCustomId('loan_apply').setLabel('Apply Now').setStyle(ButtonStyle.Primary)
       );
@@ -30,7 +31,7 @@ module.exports = {
       for (const loan of loans) {
         embed.addFields({
           name: `Loan ${loan._id.toString()}`,
-          value: `Amount: $${loan.amount}\nWeekly: $${loan.weeklyPayment}\nPayments Left: ${loan.paymentsRemaining}\nStrikes: ${loan.strikes}`
+          value: `Type: ${loan.type}\nAmount: $${loan.amount}\nWeekly: $${loan.weeklyPayment}\nPayments Left: ${loan.paymentsRemaining}\nStrikes: ${loan.strikes}`
         });
       }
       return interaction.reply({ embeds: [embed], ephemeral: true });
@@ -45,10 +46,20 @@ module.exports = {
       for (const loan of loans) {
         embed.addFields({
           name: `Loan ${loan._id.toString()}`,
-          value: `Amount: $${loan.amount}\nStatus: ${loan.status}\nStrikes: ${loan.strikes}`
+          value: `Type: ${loan.type}\nAmount: $${loan.amount}\nStatus: ${loan.status}\nStrikes: ${loan.strikes}`
         });
       }
       return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+
+    if (sub === 'pay') {
+      const { sendPaymentEmbed } = require('../services/loanService');
+      const loans = await Loan.find({ userId: interaction.user.id, status: 'active' });
+      if (!loans.length) return interaction.reply({ content: '❌ You have no active loans.', ephemeral: true });
+      for (const loan of loans) {
+        await sendPaymentEmbed(interaction.client, loan);
+      }
+      return interaction.reply({ content: '✅ Payment panel sent to your DMs.', ephemeral: true });
     }
   }
 };

--- a/backend/models/Loan.js
+++ b/backend/models/Loan.js
@@ -8,6 +8,7 @@ const LoanSchema = new mongoose.Schema({
   termWeeks: { type: Number, required: true },
   paymentsRemaining: { type: Number, required: true },
   creditScoreAtApproval: { type: Number, required: true },
+  type: { type: String, default: 'Personal' },
   strikes: { type: Number, default: 0 },
   nextPaymentDue: { type: Date, required: true },
   createdAt: { type: Date, default: Date.now },


### PR DESCRIPTION
## Summary
- support multiple loan types in the `/loan panel`
- add ability for staff to approve or deny loan applications
- log approvals/denials and DM users
- track loan type in DB
- send payment reminders and allow `/loan pay`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68681fdf65848330b53f3d8f54af03d2