### PR TITLE
Improve responsiveness across components

### DIFF
--- a/frontend/src/components/AddLicenseModal.jsx
+++ b/frontend/src/components/AddLicenseModal.jsx
@@ -57,7 +57,7 @@ const AddLicenseModal = ({ civilian, onClose, onSuccess }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-2xl w-full max-w-md shadow-2xl border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-2xl w-full max-w-md shadow-2xl border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Add New License</h2>
 
         <Listbox value={selectedLicense} onChange={setSelectedLicense} disabled={availableLicenses.length === 0}>
@@ -120,7 +120,7 @@ const AddLicenseModal = ({ civilian, onClose, onSuccess }) => {
           </p>
         )}
 
-        <div className="flex justify-end space-x-3">
+        <div className="flex flex-col sm:flex-row justify-end space-y-3 sm:space-y-0 sm:space-x-3">
           <button
             className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm"
             onClick={onClose}

--- a/frontend/src/components/AddMedicalModal.jsx
+++ b/frontend/src/components/AddMedicalModal.jsx
@@ -38,7 +38,7 @@ const AddMedicalModal = ({ civilianId, onClose, onSuccess }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-2xl w-full max-w-md shadow-2xl border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-2xl w-full max-w-md shadow-2xl border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Add Medical Record</h2>
         <textarea
           value={notes}
@@ -54,7 +54,7 @@ const AddMedicalModal = ({ civilianId, onClose, onSuccess }) => {
           </p>
         )}
 
-        <div className="flex justify-end space-x-3 mt-4">
+        <div className="flex flex-col sm:flex-row justify-end space-y-3 sm:space-y-0 sm:space-x-3 mt-4">
           <button
             className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm"
             onClick={onClose}

--- a/frontend/src/components/AddVehicleModal.jsx
+++ b/frontend/src/components/AddVehicleModal.jsx
@@ -57,9 +57,9 @@ const AddVehicleModal = ({ civilianId, onClose, onSuccess }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-2xl w-full max-w-lg border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-2xl w-full max-w-lg border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Register New Vehicle</h2>
-        <div className="grid grid-cols-2 gap-4 text-sm">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
           <input name="plate" value={formData.plate} onChange={handleChange} placeholder="Plate Number" className="bg-gray-800 rounded px-3 py-2" />
           <input name="make" value={formData.make} onChange={handleChange} placeholder="Make" className="bg-gray-800 rounded px-3 py-2" />
           <input name="model" value={formData.model} onChange={handleChange} placeholder="Model" className="bg-gray-800 rounded px-3 py-2" />
@@ -96,7 +96,7 @@ const AddVehicleModal = ({ civilianId, onClose, onSuccess }) => {
 
         {message && <p className="text-red-400 text-sm text-center mt-2">{message}</p>}
 
-        <div className="flex justify-end mt-4 space-x-3">
+        <div className="flex flex-col sm:flex-row justify-end mt-4 space-y-3 sm:space-y-0 sm:space-x-3">
           <button onClick={onClose} className="px-4 py-2 rounded bg-gray-600 hover:bg-gray-500 text-sm">Cancel</button>
           <button onClick={handleSubmit} className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-500 text-sm" disabled={loading}>
             {loading ? "Submitting..." : "Register Vehicle"}

--- a/frontend/src/components/AddWeaponModal.jsx
+++ b/frontend/src/components/AddWeaponModal.jsx
@@ -51,7 +51,7 @@ const AddWeaponModal = ({ civilianId, onClose, onSuccess }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-md shadow-xl border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-md shadow-xl border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Register New Weapon</h2>
 
         <div className="space-y-3">
@@ -94,7 +94,7 @@ const AddWeaponModal = ({ civilianId, onClose, onSuccess }) => {
           </p>
         )}
 
-        <div className="flex justify-end pt-4 space-x-2">
+        <div className="flex flex-col sm:flex-row justify-end pt-4 space-y-2 sm:space-y-0 sm:space-x-2">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm"

--- a/frontend/src/components/BankModal.jsx
+++ b/frontend/src/components/BankModal.jsx
@@ -5,7 +5,7 @@ export default function BankModal({ isOpen, onClose, title, onSubmit, children }
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white rounded-lg p-6 w-full max-w-md shadow-lg">
+      <div className="bg-gray-900 text-white rounded-lg p-4 sm:p-6 w-full max-w-md shadow-lg">
         <h2 className="text-xl font-bold mb-4">{title}</h2>
         <form
           onSubmit={(e) => {
@@ -14,7 +14,7 @@ export default function BankModal({ isOpen, onClose, title, onSubmit, children }
           }}
         >
           {children}
-          <div className="flex justify-end mt-4 gap-2">
+          <div className="flex flex-col sm:flex-row justify-end mt-4 gap-2 space-y-2 sm:space-y-0">
             <button type="button" onClick={onClose} className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded">
               Cancel
             </button>

--- a/frontend/src/components/CivilianCard.jsx
+++ b/frontend/src/components/CivilianCard.jsx
@@ -12,10 +12,10 @@ const CivilianCard = ({
   const [showLicenseModal, setShowLicenseModal] = useState(false);
 
   return (
-    <div className="bg-gray-800 text-white p-6 rounded-xl shadow-lg max-w-2xl mx-auto mt-6">
+    <div className="bg-gray-800 text-white p-4 sm:p-6 rounded-xl shadow-lg max-w-2xl mx-auto mt-6">
       <h2 className="text-2xl font-bold mb-2">{civilian.firstName} {civilian.lastName}</h2>
 
-      <div className="grid grid-cols-2 gap-y-1 text-sm">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-y-1 text-sm">
         <p><strong>DOB:</strong> {civilian.dob || civilian.dateOfBirth || "N/A"}</p>
         <p><strong>Age:</strong> {civilian.age || "N/A"}</p>
         <p><strong>Sex:</strong> {civilian.sex || "N/A"}</p>

--- a/frontend/src/components/CivilianDetailView.jsx
+++ b/frontend/src/components/CivilianDetailView.jsx
@@ -105,7 +105,7 @@ const CivilianDetailView = ({ civilian, onEdit, onDelete, onClose }) => {
 
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-60 flex items-center justify-center">
-      <div className="bg-gray-900 text-white p-6 rounded-2xl w-full max-w-6xl shadow-2xl space-y-4 max-h-[90vh] overflow-y-auto">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-2xl w-full max-w-6xl shadow-2xl space-y-4 max-h-[90vh] overflow-y-auto">
         <div className="flex justify-between items-center border-b border-gray-700 pb-2">
           <h2 className="text-3xl font-bold">{civilian.firstName} {civilian.lastName}</h2>
           <div className="relative">
@@ -177,6 +177,7 @@ const CivilianDetailView = ({ civilian, onEdit, onDelete, onClose }) => {
             <button onClick={() => setShowAddVehicle(true)} className="text-xs bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded">Add Vehicle</button>
           </div>
           {vehicles.length > 0 ? (
+            <div className="overflow-x-auto">
             <table className="w-full text-sm text-left text-gray-300">
               <thead className="text-xs text-gray-400 uppercase bg-gray-700">
                 <tr>
@@ -214,6 +215,7 @@ onClick={() => setEditVehicle(v)}  className="bg-green-600 hover:bg-green-500 te
                 ))}
               </tbody>
             </table>
+            </div>
           ) : (
             <p className="text-sm italic">No vehicles registered yet.</p>
           )}
@@ -226,6 +228,7 @@ onClick={() => setEditVehicle(v)}  className="bg-green-600 hover:bg-green-500 te
             <button onClick={() => setShowAddWeapon(true)} className="text-xs bg-red-600 hover:bg-red-500 px-2 py-1 rounded">Add Weapon</button>
           </div>
           {weapons.length > 0 ? (
+            <div className="overflow-x-auto">
             <table className="w-full text-sm text-left text-gray-300">
               <thead className="text-xs text-gray-400 uppercase bg-gray-700">
                 <tr>
@@ -260,6 +263,7 @@ onClick={() => setEditVehicle(v)}  className="bg-green-600 hover:bg-green-500 te
                 ))}
               </tbody>
             </table>
+            </div>
           ) : (
             <p className="text-sm italic">No weapons registered yet.</p>
           )}
@@ -274,7 +278,7 @@ onClick={() => setEditVehicle(v)}  className="bg-green-600 hover:bg-green-500 te
           </div>
         </div>
 
-        <div className="flex justify-end pt-2">
+        <div className="flex flex-col sm:flex-row justify-end pt-2 space-y-2 sm:space-y-0">
           <button onClick={onClose} className="bg-gray-600 hover:bg-gray-500 px-4 py-1 rounded text-sm">Close</button>
         </div>
       </div>

--- a/frontend/src/components/CivilianEditForm.jsx
+++ b/frontend/src/components/CivilianEditForm.jsx
@@ -4,7 +4,7 @@ export default function CivilianEditForm({ civilian }) {
   if (!civilian) return <p className="text-gray-400">No civilian data available.</p>;
 
   return (
-    <div className="mt-6 p-6 bg-gray-800 border border-gray-700 rounded-lg text-white max-w-xl">
+    <div className="mt-6 p-4 sm:p-6 bg-gray-800 border border-gray-700 rounded-lg text-white max-w-xl">
       <h3 className="text-xl font-semibold mb-4">
         Editing: {civilian.firstName} {civilian.lastName}
       </h3>

--- a/frontend/src/components/CivilianRecordsView.jsx
+++ b/frontend/src/components/CivilianRecordsView.jsx
@@ -6,7 +6,7 @@ const CivilianRecordsView = ({ civilian, onClose }) => {
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-60 flex items-center justify-center">
       <div
-        className="bg-gray-800 text-white p-6 rounded-lg w-full max-w-2xl shadow-lg"
+        className="bg-gray-800 text-white p-4 sm:p-6 rounded-lg w-full max-w-2xl shadow-lg"
         data-ignore-click
       >
         <h2 className="text-2xl font-semibold mb-4">
@@ -17,7 +17,7 @@ const CivilianRecordsView = ({ civilian, onClose }) => {
           This section is reserved for future records and citations.
         </p>
 
-        <div className="mt-6 flex justify-end">
+        <div className="mt-6 flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0">
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/frontend/src/components/CreateAccidentReportModal.jsx
+++ b/frontend/src/components/CreateAccidentReportModal.jsx
@@ -65,8 +65,8 @@ export default function CreateAccidentReportModal({ onClose, onSubmit }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center p-6 z-50 overflow-y-auto">
-      <div className="bg-[#1E1F24] text-white p-6 rounded-lg w-full max-w-md shadow-lg">
+    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center p-4 sm:p-6 z-50 overflow-y-auto">
+      <div className="bg-[#1E1F24] text-white p-4 sm:p-6 rounded-lg w-full max-w-md shadow-lg">
         <h2 className="text-lg font-semibold mb-4">10-50 Accident Report</h2>
         {error && <p className="text-red-400 text-sm mb-4">{error}</p>}
 
@@ -131,7 +131,7 @@ export default function CreateAccidentReportModal({ onClose, onSubmit }) {
           />
         </div>
 
-        <div className="flex justify-end gap-2 mt-6">
+        <div className="flex flex-col sm:flex-row justify-end gap-2 space-y-2 sm:space-y-0 mt-6">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded bg-[#3B3C42] hover:bg-[#4A4B50] text-sm"

--- a/frontend/src/components/CreateBoloModal.jsx
+++ b/frontend/src/components/CreateBoloModal.jsx
@@ -40,7 +40,7 @@ export default function CreateBoloModal({ onClose, onSuccess }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-md border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-md border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Create BOLO</h2>
 
         <div className="flex justify-center gap-4 mb-4">
@@ -120,7 +120,7 @@ export default function CreateBoloModal({ onClose, onSuccess }) {
 
         {message && <p className="text-red-400 text-sm text-center mt-2">{message}</p>}
 
-        <div className="flex justify-end mt-4 space-x-2">
+        <div className="flex flex-col sm:flex-row justify-end mt-4 space-y-2 sm:space-y-0 sm:space-x-2">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm"

--- a/frontend/src/components/CreateCallModal.jsx
+++ b/frontend/src/components/CreateCallModal.jsx
@@ -50,7 +50,7 @@ export default function CreateCallModal({ onClose, onSuccess }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-md border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-md border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Create New Call</h2>
 
         <div className="space-y-3">
@@ -117,7 +117,7 @@ export default function CreateCallModal({ onClose, onSuccess }) {
 
         {message && <p className="text-red-400 text-sm text-center mt-2">{message}</p>}
 
-        <div className="flex justify-end mt-4 space-x-2">
+        <div className="flex flex-col sm:flex-row justify-end mt-4 space-y-2 sm:space-y-0 sm:space-x-2">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm"

--- a/frontend/src/components/CreateCivilianModal.jsx
+++ b/frontend/src/components/CreateCivilianModal.jsx
@@ -75,7 +75,7 @@ const CreateCivilianModal = ({ onClose, onSuccess = () => {} }) => {
 
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center">
-      <div className="bg-gray-800 p-6 rounded-lg w-full max-w-3xl text-white overflow-y-auto max-h-[90vh]">
+      <div className="bg-gray-800 p-4 sm:p-6 rounded-lg w-full max-w-3xl text-white overflow-y-auto max-h-[90vh]">
         <h2 className="text-2xl font-semibold mb-6">Register New Civilian</h2>
         <form
           onSubmit={handleSubmit}
@@ -213,7 +213,7 @@ const CreateCivilianModal = ({ onClose, onSuccess = () => {} }) => {
             <div className="col-span-2 text-red-400 mt-2">{error}</div>
           )}
 
-          <div className="col-span-1 md:col-span-2 flex justify-end gap-4 mt-6">
+          <div className="col-span-1 md:col-span-2 flex flex-col sm:flex-row justify-end gap-4 space-y-2 sm:space-y-0 mt-6">
             <button
               type="button"
               onClick={onClose}

--- a/frontend/src/components/CreateReportModal.jsx
+++ b/frontend/src/components/CreateReportModal.jsx
@@ -125,7 +125,7 @@ export default function CreateReportModal({ civilian, onClose }) {
   return (
     <Dialog open={true} onClose={onClose} className="fixed z-50 inset-0 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen">
-        <Dialog.Panel className="bg-gray-900 p-6 rounded-lg shadow-lg max-w-md w-full mx-auto">
+        <Dialog.Panel className="bg-gray-900 p-4 sm:p-6 rounded-lg shadow-lg max-w-md w-full mx-auto">
           <Dialog.Title className="text-white text-xl mb-4 text-left">Create Report</Dialog.Title>
           <div className="space-y-4">
             <div>
@@ -190,7 +190,7 @@ export default function CreateReportModal({ civilian, onClose }) {
               )}
             </div>
 
-            <div className="flex space-x-2">
+            <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
               <div className="flex-1">
                 <label className="text-white block text-left">Fine ($)</label>
                 <input
@@ -229,7 +229,7 @@ export default function CreateReportModal({ civilian, onClose }) {
               <p className={`text-left text-sm font-medium ${message.includes("✅") ? "text-green-400" : "text-red-400"}`}>{message}</p>
             )}
 
-            <div className="flex justify-end">
+            <div className="flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0">
               <button
                 onClick={handleSubmit}
                 className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded"

--- a/frontend/src/components/CreateSceneReportModal.jsx
+++ b/frontend/src/components/CreateSceneReportModal.jsx
@@ -57,8 +57,8 @@ export default function CreateSceneReportModal({ onClose, onSubmit }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-start justify-center p-6 z-50 overflow-y-auto">
-      <div className="bg-[#1E1F24] text-white p-6 rounded-lg w-full max-w-md shadow-lg">
+    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-start justify-center p-4 sm:p-6 z-50 overflow-y-auto">
+      <div className="bg-[#1E1F24] text-white p-4 sm:p-6 rounded-lg w-full max-w-md shadow-lg">
         <h2 className="text-lg font-semibold mb-4">Scene Report</h2>
         {error && <p className="text-red-400 text-sm mb-4">{error}</p>}
 
@@ -121,7 +121,7 @@ export default function CreateSceneReportModal({ onClose, onSubmit }) {
           />
         </div>
 
-        <div className="flex justify-end gap-2 mt-6">
+        <div className="flex flex-col sm:flex-row justify-end gap-2 space-y-2 sm:space-y-0 mt-6">
           <button onClick={onClose} className="px-4 py-2 rounded bg-[#3B3C42] hover:bg-[#4A4B50] text-sm">Cancel</button>
           <button onClick={handleSubmit} className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-500 text-sm">Submit</button>
         </div>

--- a/frontend/src/components/CreateWarrantModal.jsx
+++ b/frontend/src/components/CreateWarrantModal.jsx
@@ -80,7 +80,7 @@ export default function CreateWarrantModal({ onClose, onSuccess }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50 p-4">
-      <div className="bg-[#1e1f24] text-white p-6 rounded-lg max-w-md w-full border border-gray-700">
+      <div className="bg-[#1e1f24] text-white p-4 sm:p-6 rounded-lg max-w-md w-full border border-gray-700">
         <h2 className="text-xl font-semibold mb-4">Create Warrant</h2>
         {error && <p className="text-red-400 text-sm mb-2">{error}</p>}
 
@@ -159,7 +159,7 @@ export default function CreateWarrantModal({ onClose, onSuccess }) {
           />
         </div>
 
-        <div className="flex justify-end gap-2 mt-6">
+        <div className="flex flex-col sm:flex-row justify-end gap-2 space-y-2 sm:space-y-0 mt-6">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded bg-gray-600 hover:bg-gray-500 text-sm"

--- a/frontend/src/components/DMVLicenseTestModal.jsx
+++ b/frontend/src/components/DMVLicenseTestModal.jsx
@@ -72,7 +72,7 @@ const DMVLicenseTestModal = ({ onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-3xl shadow-xl overflow-y-auto max-h-[90vh]">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-3xl shadow-xl overflow-y-auto max-h-[90vh]">
         <h2 className="text-2xl font-bold mb-4 text-center">📋 Take DMV Test</h2>
 
         <Listbox value={licenseType} onChange={(val) => {

--- a/frontend/src/components/EditCivilianModal.jsx
+++ b/frontend/src/components/EditCivilianModal.jsx
@@ -32,10 +32,10 @@ const EditCivilianModal = ({ civilian, onClose, onSuccess }) => {
 
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-60 flex items-center justify-center">
-      <div className="bg-gray-900 p-6 rounded-lg w-full max-w-xl text-white shadow-lg">
+      <div className="bg-gray-900 p-4 sm:p-6 rounded-lg w-full max-w-xl text-white shadow-lg">
         <h2 className="text-2xl font-bold mb-4">✏️ Edit Civilian</h2>
 
-        <form onSubmit={handleSubmit} className="grid grid-cols-2 gap-4">
+        <form onSubmit={handleSubmit} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <input name="firstName" placeholder="First Name" value={formData.firstName} onChange={handleChange} className="p-2 rounded bg-gray-700" />
           <input name="lastName" placeholder="Last Name" value={formData.lastName} onChange={handleChange} className="p-2 rounded bg-gray-700" />
           <input name="middleInitial" placeholder="Middle Initial" value={formData.middleInitial || ""} onChange={handleChange} className="p-2 rounded bg-gray-700" />
@@ -62,7 +62,7 @@ const EditCivilianModal = ({ civilian, onClose, onSuccess }) => {
           {error && <p className="text-red-400 col-span-2">{error}</p>}
           {success && <p className="text-green-400 col-span-2">{success}</p>}
 
-          <div className="col-span-2 flex justify-end gap-3 mt-4">
+          <div className="col-span-2 flex flex-col sm:flex-row justify-end gap-3 space-y-2 sm:space-y-0 mt-4">
             <button onClick={onClose} type="button" className="bg-gray-600 hover:bg-gray-500 px-4 py-2 rounded">
               Cancel
             </button>

--- a/frontend/src/components/EditVehicleModal.jsx
+++ b/frontend/src/components/EditVehicleModal.jsx
@@ -40,7 +40,7 @@ const EditVehicleModal = ({ vehicle, onClose, onSuccess }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl shadow-xl w-full max-w-xl">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl shadow-xl w-full max-w-xl">
         <h2 className="text-xl font-bold mb-4 text-center">Edit Vehicle</h2>
 
         <Listbox value={type} onChange={setType}>
@@ -85,7 +85,7 @@ const EditVehicleModal = ({ vehicle, onClose, onSuccess }) => {
           </div>
         </Listbox>
 
-        <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
           <input className="bg-gray-700 p-2 rounded" placeholder="Plate" value={plate} onChange={(e) => setPlate(e.target.value)} />
           <input className="bg-gray-700 p-2 rounded" placeholder="Make" value={make} onChange={(e) => setMake(e.target.value)} />
           <input className="bg-gray-700 p-2 rounded" placeholder="Model" value={model} onChange={(e) => setModel(e.target.value)} />
@@ -101,7 +101,7 @@ const EditVehicleModal = ({ vehicle, onClose, onSuccess }) => {
 
         {message && <p className="mb-4 text-sm text-center text-yellow-400">{message}</p>}
 
-        <div className="flex justify-end gap-3">
+        <div className="flex flex-col sm:flex-row justify-end gap-3 space-y-2 sm:space-y-0">
           <button onClick={onClose} className="bg-gray-600 hover:bg-gray-500 px-4 py-2 rounded">
             Cancel
           </button>

--- a/frontend/src/components/EditWeaponModal.jsx
+++ b/frontend/src/components/EditWeaponModal.jsx
@@ -53,7 +53,7 @@ const EditWeaponModal = ({ weaponId, onClose, onSuccess }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 p-6 rounded-xl text-white w-full max-w-md border border-gray-700">
+      <div className="bg-gray-900 p-4 sm:p-6 rounded-xl text-white w-full max-w-md border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Edit Weapon</h2>
         <div className="space-y-3">
           <input
@@ -81,7 +81,7 @@ const EditWeaponModal = ({ weaponId, onClose, onSuccess }) => {
         {message && (
           <p className="text-center text-sm mt-2 text-red-400">{message}</p>
         )}
-        <div className="flex justify-end gap-2 mt-4">
+        <div className="flex flex-col sm:flex-row justify-end gap-2 space-y-2 sm:space-y-0 mt-4">
           <button
             onClick={onClose}
             className="bg-gray-700 px-4 py-2 rounded text-sm"

--- a/frontend/src/components/MyVehiclesModal.jsx
+++ b/frontend/src/components/MyVehiclesModal.jsx
@@ -51,7 +51,7 @@ const MyVehiclesModal = ({ onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl shadow-xl w-full max-w-3xl">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl shadow-xl w-full max-w-3xl">
         <h2 className="text-2xl font-bold mb-4 text-center">My Registered Vehicles</h2>
 
         {loading ? (

--- a/frontend/src/components/OfficerSetupModal.jsx
+++ b/frontend/src/components/OfficerSetupModal.jsx
@@ -59,7 +59,7 @@ export default function OfficerSetupModal({ onCreated }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
-      <div className="bg-gray-800 p-6 rounded-lg w-full max-w-md text-white">
+      <div className="bg-gray-800 p-4 sm:p-6 rounded-lg w-full max-w-md text-white">
         <h2 className="text-xl font-bold mb-4">Officer Registration</h2>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
@@ -124,7 +124,7 @@ export default function OfficerSetupModal({ onCreated }) {
 
           {error && <p className="text-red-400 text-sm">{error}</p>}
 
-          <div className="flex justify-end gap-2">
+          <div className="flex flex-col sm:flex-row justify-end gap-2 space-y-2 sm:space-y-0">
             <button
               type="button"
               onClick={() => window.location.reload()}

--- a/frontend/src/components/SelectSubdivisionModal.jsx
+++ b/frontend/src/components/SelectSubdivisionModal.jsx
@@ -18,7 +18,7 @@ export default function SelectSubdivisionModal({ onClose, onSave }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-md border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-md border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Select Subdivision</h2>
 
         <select
@@ -31,7 +31,7 @@ export default function SelectSubdivisionModal({ onClose, onSave }) {
           ))}
         </select>
 
-        <div className="flex justify-end space-x-2">
+        <div className="flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-2">
           <button onClick={onClose} className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm">Cancel</button>
           <button onClick={handleSubmit} className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-500 text-sm">Save</button>
         </div>

--- a/frontend/src/components/TenCodesModal.jsx
+++ b/frontend/src/components/TenCodesModal.jsx
@@ -73,7 +73,7 @@ const CODES = [
 export default function TenCodesModal({ onClose }) {
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-3xl border border-gray-700 max-h-[90vh] overflow-y-auto">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-3xl border border-gray-700 max-h-[90vh] overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-semibold">10 Codes Reference</h2>
           <button

--- a/frontend/src/components/UseOfForceModal.jsx
+++ b/frontend/src/components/UseOfForceModal.jsx
@@ -59,8 +59,8 @@ export default function CreateUseOfForceModal({ onClose, onSubmit }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center p-6 z-50 overflow-y-auto">
-      <div className="bg-[#1E1F24] text-white p-6 rounded-lg w-full max-w-md shadow-lg">
+    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center p-4 sm:p-6 z-50 overflow-y-auto">
+      <div className="bg-[#1E1F24] text-white p-4 sm:p-6 rounded-lg w-full max-w-md shadow-lg">
         <h2 className="text-lg font-semibold mb-4">Use of Force Report</h2>
         {error && <p className="text-red-400 text-sm mb-4">{error}</p>}
 
@@ -128,7 +128,7 @@ export default function CreateUseOfForceModal({ onClose, onSubmit }) {
           />
         </div>
 
-        <div className="flex justify-end mt-6 gap-2">
+        <div className="flex flex-col sm:flex-row justify-end mt-6 gap-2 space-y-2 sm:space-y-0">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded bg-[#3B3C42] hover:bg-[#4A4B50] text-sm"

--- a/frontend/src/components/ViewBoloDetailsModal.jsx
+++ b/frontend/src/components/ViewBoloDetailsModal.jsx
@@ -3,7 +3,7 @@ import React from "react";
 export default function ViewBoloDetailsModal({ bolo, onClose }) {
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-lg border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-lg border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">BOLO Details</h2>
 
         <div className="space-y-2 text-sm">
@@ -26,7 +26,7 @@ export default function ViewBoloDetailsModal({ bolo, onClose }) {
           <p><strong>Created At:</strong> {new Date(bolo.createdAt).toLocaleString()}</p>
         </div>
 
-        <div className="flex justify-end mt-4">
+        <div className="flex flex-col sm:flex-row justify-end mt-4 space-y-2 sm:space-y-0">
           <button
             onClick={onClose}
             className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm"

--- a/frontend/src/components/ViewCallDetailsModal.jsx
+++ b/frontend/src/components/ViewCallDetailsModal.jsx
@@ -5,7 +5,7 @@ export default function ViewCallDetailsModal({ call, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <div className="bg-gray-900 text-white p-6 rounded-xl w-full max-w-lg border border-gray-700">
+      <div className="bg-gray-900 text-white p-4 sm:p-6 rounded-xl w-full max-w-lg border border-gray-700">
         <h2 className="text-xl font-semibold mb-4 text-center">Call Details</h2>
 
         <div className="space-y-2 text-sm">
@@ -22,7 +22,7 @@ export default function ViewCallDetailsModal({ call, onClose }) {
           )}
         </div>
 
-        <div className="flex justify-end mt-4">
+        <div className="flex flex-col sm:flex-row justify-end mt-4 space-y-2 sm:space-y-0">
           <button
             onClick={onClose}
             className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm"


### PR DESCRIPTION
## Summary
- adjust paddings to `p-4 sm:p-6` for modal components
- add responsive grid columns and button layouts
- wrap tables in overflow containers for small screens
- ensure all component action areas stack on mobile

## Testing
- `npm test --prefix frontend --silent` *(fails: SyntaxError from axios import)*

------
https://chatgpt.com/codex/tasks/task_e_688d34700c3483308836a0c0d9bd6990