### PR TITLE
feat: allow bank account renaming

### DIFF
--- a/backend/bot/index.js
+++ b/backend/bot/index.js
@@ -62,6 +62,7 @@ const formatStorePage = require('./utils/formatStorePage');
 const scheduleFineCheckUtil = require('./utils/scheduleFineCheck');
 const sendClockEmbedUtil = require("./utils/sendClockEmbed");
 const sendFinancialLogEmbedUtil = require('./utils/sendFinancialLogEmbed');
+const sendAccountRenameEmbedUtil = require('./utils/sendAccountRenameEmbed');
 
 module.exports = {
   client,
@@ -73,5 +74,6 @@ module.exports = {
   scheduleFineCheck: (...args) => scheduleFineCheckUtil(client, ...args),
   sendClockEmbed: (...args) => sendClockEmbedUtil(client, ...args),
   sendFinancialLogEmbed: (...args) => sendFinancialLogEmbedUtil(client, ...args),
+  sendAccountRenameEmbed: (...args) => sendAccountRenameEmbedUtil(client, ...args),
   scheduleLoanPayment: (...args) => schedulePayment(client, ...args)
 };

--- a/backend/bot/utils/sendAccountRenameEmbed.js
+++ b/backend/bot/utils/sendAccountRenameEmbed.js
@@ -1,0 +1,14 @@
+const logError = require('./logError');
+
+async function sendAccountRenameEmbed(client, embed) {
+  try {
+    const channel = await client.channels.fetch('1373043842340622436');
+    await channel.send({ embeds: [embed] });
+    return true;
+  } catch (err) {
+    logError('Send account rename embed', err);
+    return false;
+  }
+}
+
+module.exports = sendAccountRenameEmbed;

--- a/backend/models/BankAccount.js
+++ b/backend/models/BankAccount.js
@@ -11,6 +11,10 @@ const BankAccountSchema = new mongoose.Schema({
     enum: ["Checking", "Savings", "Business Checking", "Business Savings"],
     required: true,
   },
+  name: {
+    type: String,
+    default: null,
+  },
   accountNumber: {
     type: String,
     unique: true,


### PR DESCRIPTION
## Summary
- allow bank account names to be customized
- log account name changes to dedicated Discord channel
- surface custom account names throughout banking UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68954facca94833096cd81d1ad6a7530