### PR TITLE
fix: support multiple CORS origins

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -35,6 +35,10 @@ const app = express();
 const PORT = process.env.PORT || 8080;
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
 const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8080";
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(",")
+  : [FRONTEND_URL]
+).map((origin) => origin.trim());
 
 // ✅ Required for Railway & HTTPS proxies (fixes cookie not setting)
 app.set("trust proxy", 1);
@@ -42,10 +46,17 @@ app.set("trust proxy", 1);
 // Middleware
 app.use(express.json());
 
-app.use(cors({
-  origin: FRONTEND_URL,
-  credentials: true,
-}));
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || ALLOWED_ORIGINS.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(null, false);
+    },
+    credentials: true,
+  })
+);
 
 app.use(
   session({


### PR DESCRIPTION
## Summary
- allow comma-separated list of frontend origins for CORS via `ALLOWED_ORIGINS`
- gracefully reject disallowed origins without throwing server errors

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fd8ede1e08330b791b7e0a2dd6ec6